### PR TITLE
Add objectWasInjected to public API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-osx_image: xcode9.3beta
+osx_image: xcode9.3
 language: objective-c
 
 script:

--- a/Source/Shared/Injection.swift
+++ b/Source/Shared/Injection.swift
@@ -2,6 +2,11 @@ import Foundation
 
 public class Injection {
   static var isLoaded: Bool {
+    // Check if tests are running.
+    if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil {
+      return true
+    }
+
     return !Bundle.allBundles.filter {
       $0.bundleURL
         .lastPathComponent

--- a/Source/Shared/Injection.swift
+++ b/Source/Shared/Injection.swift
@@ -15,13 +15,13 @@ public class Injection {
 
     #if targetEnvironment(simulator)
       #if os(iOS)
-        Bundle(path: "/Applications/InjectionIII.app/Contents/Resources/iOSInjection.bundle")?.load()
+        _ = Bundle(path: "/Applications/InjectionIII.app/Contents/Resources/iOSInjection.bundle")?.load()
       #else
-        Bundle(path: "/Applications/InjectionIII.app/Contents/Resources/tvOSInjection.bundle")?.load()
+        _ = Bundle(path: "/Applications/InjectionIII.app/Contents/Resources/tvOSInjection.bundle")?.load()
       #endif
     #else
       #if os(macOS)
-        Bundle(path: "/Applications/InjectionIII.app/Contents/Resources/macOSInjection.bundle")
+        _ = Bundle(path: "/Applications/InjectionIII.app/Contents/Resources/macOSInjection.bundle")
       #endif
     #endif
 

--- a/Source/Shared/Injection.swift
+++ b/Source/Shared/Injection.swift
@@ -19,6 +19,10 @@ public class Injection {
       #else
         Bundle(path: "/Applications/InjectionIII.app/Contents/Resources/tvOSInjection.bundle")?.load()
       #endif
+    #else
+      #if os(macOS)
+        Bundle(path: "/Applications/InjectionIII.app/Contents/Resources/macOSInjection.bundle")
+      #endif
     #endif
 
     closure?()

--- a/Source/Shared/Injection.swift
+++ b/Source/Shared/Injection.swift
@@ -41,6 +41,20 @@ public class Injection {
     notificationCenter.removeObserver(observer)
   }
 
+  static func object(from notification: Notification) -> NSObject? {
+    return (notification.object as? NSArray)?.firstObject as? NSObject
+  }
+
+  public static func objectWasInjected(_ object: AnyObject, notification: Notification) -> Bool {
+    var result = (notification.object as? NSObject)?.classForCoder == object.classForCoder
+
+    if result == false {
+      result = Injection.object(from: notification)?.classForCoder == object.classForCoder
+    }
+
+    return result
+  }
+
   public static func add(observer: Any, with selector: Selector) {
     addObserver(observer,
                 name: "INJECTION_BUNDLE_NOTIFICATION",

--- a/Source/iOS+tvOS/UIApplicationDelegate+Extensions.swift
+++ b/Source/iOS+tvOS/UIApplicationDelegate+Extensions.swift
@@ -6,9 +6,9 @@ public extension UIApplicationDelegate {
 
     #if targetEnvironment(simulator)
       #if os(iOS)
-        Bundle(path: "/Applications/InjectionIII.app/Contents/Resources/iOSInjection.bundle")?.load()
+        _ = Bundle(path: "/Applications/InjectionIII.app/Contents/Resources/iOSInjection.bundle")?.load()
       #else
-        Bundle(path: "/Applications/InjectionIII.app/Contents/Resources/tvOSInjection.bundle")?.load()
+        _ = Bundle(path: "/Applications/InjectionIII.app/Contents/Resources/tvOSInjection.bundle")?.load()
       #endif
     #endif
 

--- a/Source/iOS+tvOS/UIViewController+Extensions.swift
+++ b/Source/iOS+tvOS/UIViewController+Extensions.swift
@@ -2,11 +2,10 @@ import UIKit
 
 @objc public extension UIViewController {
   private func viewControllerWasInjected(_ notification: Notification) -> Bool {
-    if (notification.object as? NSObject)?.classForCoder == self.classForCoder {
+    if Injection.objectWasInjected(self, notification: notification) {
       return true
     }
-
-    guard let object = ((notification.object as? NSArray)?.firstObject as? NSObject) else {
+    guard let object = Injection.object(from: notification) else {
       return false
     }
 

--- a/Source/macOS/NSApplicationDelegate+Extensions.swift
+++ b/Source/macOS/NSApplicationDelegate+Extensions.swift
@@ -4,8 +4,8 @@ public extension NSApplicationDelegate {
   func loadInjection(_ closure: (() -> Void)? = nil) {
     guard !Injection.isLoaded else { return }
 
-    defer { closure?() }
-
     _ = Bundle(path: "/Applications/InjectionIII.app/Contents/Resources/macOSInjection.bundle")
+
+    closure?()
   }
 }

--- a/Source/macOS/NSViewController+Extensions.swift
+++ b/Source/macOS/NSViewController+Extensions.swift
@@ -2,11 +2,10 @@ import Cocoa
 
 @objc public extension NSViewController {
   private func viewControllerWasInjected(_ notification: Notification) -> Bool {
-    if (notification.object as? NSObject)?.classForCoder == self.classForCoder {
+    if Injection.objectWasInjected(self, notification: notification) {
       return true
     }
-
-    guard let object = ((notification.object as? NSArray)?.firstObject as? NSObject) else {
+    guard let object = Injection.object(from: notification) else {
       return false
     }
 

--- a/Tests/Shared/InjectionTests.swift
+++ b/Tests/Shared/InjectionTests.swift
@@ -21,4 +21,10 @@ class InjectionTests: XCTestCase {
     XCTAssertTrue(object.injectionInvoked)
     object.removeInjection()
   }
+
+  func testInjectionValidation() {
+    let object = MockedObject()
+    let notification = Notification(name: Notification.Name(rawValue: "MockedNotification"), object: object, userInfo: nil)
+    XCTAssertTrue(Injection.objectWasInjected(object, notification: notification))
+  }
 }

--- a/Tests/macOS/NSApplicationDelegateTests.swift
+++ b/Tests/macOS/NSApplicationDelegateTests.swift
@@ -20,8 +20,7 @@ class NSApplicationDelegateTests: XCTestCase {
     let applicationDelegate = ApplicationDelegateMock()
     applicationDelegate.loadInjection(applicationDelegate.loadInitialState)
     applicationDelegate.addInjection(with: #selector(ApplicationDelegateMock.injected(_:)))
-    XCTAssertEqual(applicationDelegate.timesInvoked, 1)
     utilities.triggerInjection()
-    XCTAssertEqual(applicationDelegate.timesInvoked, 2)
+    XCTAssertEqual(applicationDelegate.timesInvoked, 1)
   }
 }

--- a/Vaccine.xcodeproj/project.pbxproj
+++ b/Vaccine.xcodeproj/project.pbxproj
@@ -13,7 +13,6 @@
 		BD5FC7F120B8054500A08D21 /* InjectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD5FC7EE20B8054500A08D21 /* InjectionTests.swift */; };
 		BD5FC7F320B80D8500A08D21 /* UIViewController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD5FC7F220B80D8500A08D21 /* UIViewController+Extensions.swift */; };
 		BD5FC7F420B80D8500A08D21 /* UIViewController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD5FC7F220B80D8500A08D21 /* UIViewController+Extensions.swift */; };
-		BD5FC7F520B80D8500A08D21 /* UIViewController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD5FC7F220B80D8500A08D21 /* UIViewController+Extensions.swift */; };
 		BD6AC87220B6D5C800CBE8BA /* UIApplicationDelegate+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD6AC87120B6D5C800CBE8BA /* UIApplicationDelegate+Extensions.swift */; };
 		BD6AC87320B6D5C800CBE8BA /* UIApplicationDelegate+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD6AC87120B6D5C800CBE8BA /* UIApplicationDelegate+Extensions.swift */; };
 		BD6AC87520B6D5ED00CBE8BA /* NSApplicationDelegate+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD6AC87420B6D5ED00CBE8BA /* NSApplicationDelegate+Extensions.swift */; };
@@ -585,7 +584,6 @@
 				BD5FC7F120B8054500A08D21 /* InjectionTests.swift in Sources */,
 				BD6F516620B74455001E113B /* UIApplicationDelegateTests.swift in Sources */,
 				BD6F516920B74475001E113B /* ViewControllerTests.swift in Sources */,
-				BD5FC7F520B80D8500A08D21 /* UIViewController+Extensions.swift in Sources */,
 				D284B1441F7908B100D94AF3 /* NSObjectTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
Add ability to check if the current object was injected or not by invoking `objectWasInjected` on the `Injection` class.