### PR TITLE
Remove injection removal methods from API as they are redundant

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,6 @@ What you need to do in your view controllers is to listen to the incoming notifi
 
 ```swift
 class ViewController: UIViewController {
-  deinit {
-    Injection.remove(observer: self)
-  }
-
   override func viewDidLoad() {
     super.viewDidLoad()
     Injection.add(observer: self, with: #selector(injected(_:)))
@@ -116,10 +112,6 @@ class CustomView: UIView {
 
   required init?(coder aDecoder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
-  }
-
-  deinit {
-    removeInjection()
   }
 
   private func loadView() {

--- a/Source/Shared/Injection.swift
+++ b/Source/Shared/Injection.swift
@@ -46,10 +46,6 @@ public class Injection {
                                    object: object)
   }
 
-  private static func removeObserver(_ observer: Any, notificationCenter: NotificationCenter = .default) {
-    notificationCenter.removeObserver(observer)
-  }
-
   static func object(from notification: Notification) -> NSObject? {
     return (notification.object as? NSArray)?.firstObject as? NSObject
   }
@@ -68,10 +64,6 @@ public class Injection {
     addObserver(observer,
                 name: "INJECTION_BUNDLE_NOTIFICATION",
                 selector: selector)
-  }
-
-  public static func remove(observer: Any) {
-    removeObserver(observer)
   }
 }
 

--- a/Source/Shared/NSObject+Extensions.swift
+++ b/Source/Shared/NSObject+Extensions.swift
@@ -15,8 +15,4 @@ public extension NSObject {
     addObserver(name: "INJECTION_BUNDLE_NOTIFICATION",
                 selector: selector)
   }
-  
-  func removeInjection(notificationCenter: NotificationCenter = .default) {
-    notificationCenter.removeObserver(self)
-  }
 }

--- a/Tests/Shared/InjectionTests.swift
+++ b/Tests/Shared/InjectionTests.swift
@@ -19,7 +19,6 @@ class InjectionTests: XCTestCase {
     Injection.add(observer: object, with: #selector(MockedObject.injected(_:)))
     utilities.triggerInjection()
     XCTAssertTrue(object.injectionInvoked)
-    object.removeInjection()
   }
 
   func testInjectionValidation() {

--- a/Tests/iOS+tvOS/ViewControllerTests.swift
+++ b/Tests/iOS+tvOS/ViewControllerTests.swift
@@ -12,10 +12,6 @@ class ViewControllerTests: XCTestCase {
     lazy var childViewController = ViewControllerMock()
     var timesInvoked: Int = 0
 
-    deinit {
-      removeInjection()
-    }
-
     override func viewDidLoad() {
       super.viewDidLoad()
       addInjection(with: #selector(injected(_:)))

--- a/Tests/macOS/ViewControllerTests.swift
+++ b/Tests/macOS/ViewControllerTests.swift
@@ -17,10 +17,6 @@ class ViewControllerTests: XCTestCase {
     lazy var childViewController = ViewControllerMock()
     var timesInvoked: Int = 0
 
-    deinit {
-      Injection.remove(observer: self)
-    }
-
     override func loadView() {
       self.view = NSView()
       self.view.wantsLayer = true


### PR DESCRIPTION
> If your app targets iOS 9.0 and later or macOS 10.11 and later, you don't need to unregister an observer in its dealloc method.

Fixes https://github.com/zenangst/Vaccine/issues/1