### PR TITLE
Feature UIScreen extension

### DIFF
--- a/Source/iOS/Device.swift
+++ b/Source/iOS/Device.swift
@@ -1,0 +1,62 @@
+import UIKit
+
+public enum Device {
+  public enum Orientation {
+    case portrait, landscape
+  }
+
+  case iPhone4(orientation: Orientation?)
+  case iPhoneSE(orientation: Orientation?)
+  case iPhone8(orientation: Orientation?)
+  case iPhone8Plus(orientation: Orientation?)
+  case iPhoneX(orientation: Orientation?)
+  case iPad(orientation: Orientation?)
+
+  var size: CGSize {
+    switch self {
+    case .iPhone4(_):
+      return .init(width: 240, height: 320)
+    case .iPhoneSE(_):
+      return .init(width: 320, height: 568)
+    case .iPhone8(_):
+      return .init(width: 375, height: 667)
+    case .iPhone8Plus(_):
+      return .init(width: 414, height: 736)
+    case .iPhoneX(_):
+      return .init(width: 375, height: 812)
+    case .iPad(_):
+      return .init(width: 768, height: 1024)
+    }
+  }
+
+  var rawValue: CGRect {
+    var result: CGRect = .zero
+
+    switch self {
+    case .iPhone4(let orientation),
+         .iPhoneSE(let orientation),
+         .iPhone8(let orientation),
+         .iPhone8Plus(let orientation),
+         .iPhoneX(let orientation),
+         .iPad(let orientation):
+      switch orientation {
+      case .portrait?:
+        result.size = CGSize(width: self.size.width, height: self.size.height)
+      case .landscape?:
+        result.size = CGSize(width: self.size.height, height: self.size.width)
+      case .none:
+        switch UIDevice.current.orientation {
+        case .faceDown, .faceUp, .portrait, .portraitUpsideDown, .unknown:
+          result.size = CGSize(width: self.size.width, height: self.size.height)
+        case .landscapeLeft, .landscapeRight:
+          result.size = CGSize(width: self.size.height, height: self.size.width)
+        }
+      }
+    }
+
+    result.origin.x = UIScreen.main.bounds.width / 2 - result.width / 2
+    result.origin.y = UIScreen.main.bounds.height / 2 - result.height / 2
+
+    return result
+  }
+}

--- a/Source/iOS/UIScreen+Extensions.swift
+++ b/Source/iOS/UIScreen+Extensions.swift
@@ -1,0 +1,7 @@
+import UIKit
+
+public extension UIScreen {
+  static func device(_ device: Device) -> CGRect {
+    return device.rawValue
+  }
+}

--- a/Tests/iOS/UIScreenTests.swift
+++ b/Tests/iOS/UIScreenTests.swift
@@ -1,0 +1,149 @@
+import XCTest
+import Vaccine
+
+class UIScreenTests: XCTestCase {
+  let screenBounds = UIScreen.main.bounds
+
+  func testIPhone8WithoutOrientation() {
+    let result = UIScreen.device(.iPhone8(orientation: nil))
+    let expectedSize = CGSize(width: 375, height: 667)
+    let expectedResult = CGRect(
+      origin: CGPoint(x: screenBounds.size.width / 2 - expectedSize.width / 2,
+                      y: screenBounds.size.height / 2 - expectedSize.height / 2),
+      size: expectedSize
+    )
+    XCTAssertEqual(result, expectedResult)
+  }
+
+  func testIPhone4Portrait() {
+    let result = UIScreen.device(.iPhone4(orientation: .portrait))
+    let expectedSize = CGSize(width: 240, height: 320)
+    let expectedResult = CGRect(
+      origin: CGPoint(x: screenBounds.size.width / 2 - expectedSize.width / 2,
+                      y: screenBounds.size.height / 2 - expectedSize.height / 2),
+      size: expectedSize
+    )
+    XCTAssertEqual(result, expectedResult)
+  }
+
+  func testIPhoneSEPortrait() {
+    let result = UIScreen.device(.iPhoneSE(orientation: .portrait))
+    let expectedSize = CGSize(width: 320, height: 568)
+    let expectedResult = CGRect(
+      origin: CGPoint(x: screenBounds.size.width / 2 - expectedSize.width / 2,
+                      y: screenBounds.size.height / 2 - expectedSize.height / 2),
+      size: expectedSize
+    )
+    XCTAssertEqual(result, expectedResult)
+  }
+
+  func testIPhone8Portrait() {
+    let result = UIScreen.device(.iPhone8(orientation: .portrait))
+    let expectedSize = CGSize(width: 375, height: 667)
+    let expectedResult = CGRect(
+      origin: CGPoint(x: screenBounds.size.width / 2 - expectedSize.width / 2,
+                      y: screenBounds.size.height / 2 - expectedSize.height / 2),
+      size: expectedSize
+    )
+    XCTAssertEqual(result, expectedResult)
+  }
+
+  func testIPhone8PlusPortrait() {
+    let result = UIScreen.device(.iPhone8Plus(orientation: .portrait))
+    let expectedSize = CGSize(width: 414, height: 736)
+    let expectedResult = CGRect(
+      origin: CGPoint(x: screenBounds.size.width / 2 - expectedSize.width / 2,
+                      y: screenBounds.size.height / 2 - expectedSize.height / 2),
+      size: expectedSize
+    )
+    XCTAssertEqual(result, expectedResult)
+  }
+
+  func testIPhoneXPortrait() {
+    let result = UIScreen.device(.iPhoneX(orientation: .portrait))
+    let expectedSize = CGSize(width: 375, height: 812)
+    let expectedResult = CGRect(
+      origin: CGPoint(x: screenBounds.size.width / 2 - expectedSize.width / 2,
+                      y: screenBounds.size.height / 2 - expectedSize.height / 2),
+      size: expectedSize
+    )
+    XCTAssertEqual(result, expectedResult)
+  }
+
+  func testIPadPortrait() {
+    let result = UIScreen.device(.iPad(orientation: .portrait))
+    let expectedSize = CGSize(width: 768, height: 1024)
+    let expectedResult = CGRect(
+      origin: CGPoint(x: screenBounds.size.width / 2 - expectedSize.width / 2,
+                      y: screenBounds.size.height / 2 - expectedSize.height / 2),
+      size: expectedSize
+    )
+    XCTAssertEqual(result, expectedResult)
+  }
+
+  func testIPhone4Landscape() {
+    let result = UIScreen.device(.iPhone4(orientation: .landscape))
+    let expectedSize = CGSize(width: 320, height: 240)
+    let expectedResult = CGRect(
+      origin: CGPoint(x: screenBounds.size.width / 2 - expectedSize.width / 2,
+                      y: screenBounds.size.height / 2 - expectedSize.height / 2),
+      size: expectedSize
+    )
+    XCTAssertEqual(result, expectedResult)
+  }
+
+  func testIPhoneSELandscape() {
+    let result = UIScreen.device(.iPhoneSE(orientation: .landscape))
+    let expectedSize = CGSize(width: 568, height: 320)
+    let expectedResult = CGRect(
+      origin: CGPoint(x: screenBounds.size.width / 2 - expectedSize.width / 2,
+                      y: screenBounds.size.height / 2 - expectedSize.height / 2),
+      size: expectedSize
+    )
+    XCTAssertEqual(result, expectedResult)
+  }
+
+  func testIPhone8Landscape() {
+    let result = UIScreen.device(.iPhone8(orientation: .landscape))
+    let expectedSize = CGSize(width: 667, height: 375)
+    let expectedResult = CGRect(
+      origin: CGPoint(x: screenBounds.size.width / 2 - expectedSize.width / 2,
+                      y: screenBounds.size.height / 2 - expectedSize.height / 2),
+      size: expectedSize
+    )
+    XCTAssertEqual(result, expectedResult)
+  }
+
+  func testIPhone8PlusLandscape() {
+    let result = UIScreen.device(.iPhone8Plus(orientation: .landscape))
+    let expectedSize = CGSize(width: 736, height: 414)
+    let expectedResult = CGRect(
+      origin: CGPoint(x: screenBounds.size.width / 2 - expectedSize.width / 2,
+                      y: screenBounds.size.height / 2 - expectedSize.height / 2),
+      size: expectedSize
+    )
+    XCTAssertEqual(result, expectedResult)
+  }
+
+  func testIPhoneXLandscape() {
+    let result = UIScreen.device(.iPhoneX(orientation: .landscape))
+    let expectedSize = CGSize(width: 812, height: 375)
+    let expectedResult = CGRect(
+      origin: CGPoint(x: screenBounds.size.width / 2 - expectedSize.width / 2,
+                      y: screenBounds.size.height / 2 - expectedSize.height / 2),
+      size: expectedSize
+    )
+    XCTAssertEqual(result, expectedResult)
+  }
+
+  func testIPadLandscape() {
+    let result = UIScreen.device(.iPad(orientation: .landscape))
+    let expectedSize = CGSize(width: 1024, height: 768)
+    let expectedResult = CGRect(
+      origin: CGPoint(x: screenBounds.size.width / 2 - expectedSize.width / 2,
+                      y: screenBounds.size.height / 2 - expectedSize.height / 2),
+      size: expectedSize
+    )
+    XCTAssertEqual(result, expectedResult)
+  }
+}

--- a/Vaccine.xcodeproj/project.pbxproj
+++ b/Vaccine.xcodeproj/project.pbxproj
@@ -33,6 +33,8 @@
 		BD6F516B20B7D6BA001E113B /* Injection.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD6F516A20B7D6BA001E113B /* Injection.swift */; };
 		BD6F516C20B7D6BA001E113B /* Injection.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD6F516A20B7D6BA001E113B /* Injection.swift */; };
 		BD6F516D20B7D6BA001E113B /* Injection.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD6F516A20B7D6BA001E113B /* Injection.swift */; };
+		BDEA432620C9216C00CF30A2 /* UIScreen+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEA432520C9216C00CF30A2 /* UIScreen+Extensions.swift */; };
+		BDEA432B20C921B600CF30A2 /* Device.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEA432A20C921B600CF30A2 /* Device.swift */; };
 		D284B1051F79038B00D94AF3 /* Vaccine.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D284B0FC1F79038B00D94AF3 /* Vaccine.framework */; };
 		D284B1381F7906DB00D94AF3 /* Info-iOS-Tests.plist in Resources */ = {isa = PBXBuildFile; fileRef = D284B12F1F7906DA00D94AF3 /* Info-iOS-Tests.plist */; };
 		D284B1391F7906DB00D94AF3 /* Info-tvOS-Tests.plist in Resources */ = {isa = PBXBuildFile; fileRef = D284B1301F7906DA00D94AF3 /* Info-tvOS-Tests.plist */; };
@@ -85,6 +87,8 @@
 		BD6F516420B74455001E113B /* UIApplicationDelegateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIApplicationDelegateTests.swift; sourceTree = "<group>"; };
 		BD6F516720B74475001E113B /* ViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewControllerTests.swift; sourceTree = "<group>"; };
 		BD6F516A20B7D6BA001E113B /* Injection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Injection.swift; sourceTree = "<group>"; };
+		BDEA432520C9216C00CF30A2 /* UIScreen+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIScreen+Extensions.swift"; sourceTree = "<group>"; };
+		BDEA432A20C921B600CF30A2 /* Device.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Device.swift; sourceTree = "<group>"; };
 		D284B0FC1F79038B00D94AF3 /* Vaccine.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Vaccine.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D284B1041F79038B00D94AF3 /* Vaccine-tvOS-Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Vaccine-tvOS-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D284B1181F79039F00D94AF3 /* Vaccine.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Vaccine.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -162,6 +166,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		BDEA432920C921AA00CF30A2 /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				BDEA432520C9216C00CF30A2 /* UIScreen+Extensions.swift */,
+				BDEA432A20C921B600CF30A2 /* Device.swift */,
+			);
+			path = iOS;
+			sourceTree = "<group>";
+		};
 		D284B0F41F79024300D94AF3 /* macOS */ = {
 			isa = PBXGroup;
 			children = (
@@ -249,6 +262,7 @@
 		D5C629691C3A809D007F7B7C /* Source */ = {
 			isa = PBXGroup;
 			children = (
+				BDEA432920C921AA00CF30A2 /* iOS */,
 				D5C6296A1C3A809D007F7B7C /* iOS+tvOS */,
 				D284B0F41F79024300D94AF3 /* macOS */,
 				D5C6296E1C3A809D007F7B7C /* Shared */,
@@ -606,9 +620,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				BD6F516B20B7D6BA001E113B /* Injection.swift in Sources */,
+				BDEA432620C9216C00CF30A2 /* UIScreen+Extensions.swift in Sources */,
 				BD6AC87220B6D5C800CBE8BA /* UIApplicationDelegate+Extensions.swift in Sources */,
 				BD5FC7F320B80D8500A08D21 /* UIViewController+Extensions.swift in Sources */,
 				BD6AC87720B6D61B00CBE8BA /* NSObject+Extensions.swift in Sources */,
+				BDEA432B20C921B600CF30A2 /* Device.swift in Sources */,
 				BD4B8C4A20C860CB00836815 /* TypeAlias.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Vaccine.xcodeproj/project.pbxproj
+++ b/Vaccine.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		BD2F6E6420C93B3200621BC8 /* UIScreenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2F6E6320C93B3200621BC8 /* UIScreenTests.swift */; };
 		BD4B8C4A20C860CB00836815 /* TypeAlias.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4B8C4920C860CB00836815 /* TypeAlias.swift */; };
 		BD4B8C4B20C860CB00836815 /* TypeAlias.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4B8C4920C860CB00836815 /* TypeAlias.swift */; };
 		BD4B8C4C20C860CB00836815 /* TypeAlias.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4B8C4920C860CB00836815 /* TypeAlias.swift */; };
@@ -73,6 +74,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		BD2F6E6320C93B3200621BC8 /* UIScreenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIScreenTests.swift; sourceTree = "<group>"; };
 		BD4B8C4920C860CB00836815 /* TypeAlias.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeAlias.swift; sourceTree = "<group>"; };
 		BD592EB720B837BB006DE955 /* NSViewController+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSViewController+Extensions.swift"; sourceTree = "<group>"; };
 		BD5FC7EE20B8054500A08D21 /* InjectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InjectionTests.swift; sourceTree = "<group>"; };
@@ -166,6 +168,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		BD2F6E6220C93B2000621BC8 /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				BD2F6E6320C93B3200621BC8 /* UIScreenTests.swift */,
+			);
+			name = iOS;
+			path = Tests/iOS;
+			sourceTree = SOURCE_ROOT;
+		};
 		BDEA432920C921AA00CF30A2 /* iOS */ = {
 			isa = PBXGroup;
 			children = (
@@ -296,6 +307,7 @@
 				D284B12F1F7906DA00D94AF3 /* Info-iOS-Tests.plist */,
 				D284B1331F7906DA00D94AF3 /* Info-macOS-Tests.plist */,
 				D284B1301F7906DA00D94AF3 /* Info-tvOS-Tests.plist */,
+				BD2F6E6220C93B2000621BC8 /* iOS */,
 				D284B1351F7906DA00D94AF3 /* iOS+tvOS */,
 				D284B12D1F7906DA00D94AF3 /* macOS */,
 				D284B1311F7906DA00D94AF3 /* Shared */,
@@ -636,6 +648,7 @@
 				BD6F516820B74475001E113B /* ViewControllerTests.swift in Sources */,
 				BD6F515F20B73A6E001E113B /* Utilities.swift in Sources */,
 				D284B1461F7908B300D94AF3 /* NSObjectTests.swift in Sources */,
+				BD2F6E6420C93B3200621BC8 /* UIScreenTests.swift in Sources */,
 				BD5FC7EF20B8054500A08D21 /* InjectionTests.swift in Sources */,
 				BD6F516520B74455001E113B /* UIApplicationDelegateTests.swift in Sources */,
 				D284B1471F7908B800D94AF3 /* iOStvOSTests.swift in Sources */,


### PR DESCRIPTION
Introduces extension on `UIScreen` which  adds `.device()` method. This method can be used to manipulate the current window bounds using a device enum. It adds the ability to change the screen bounds based on a bunch of pre-defined device enums without having to recompile the application.