### PR TITLE
Don't remove child views and views for navigation controllers

### DIFF
--- a/Source/iOS+tvOS/UIViewController+Extensions.swift
+++ b/Source/iOS+tvOS/UIViewController+Extensions.swift
@@ -41,8 +41,12 @@ import UIKit
     guard viewControllerWasInjected(notification) else { return }
 
     NotificationCenter.default.removeObserver(self)
-    removeChildViewControllers()
-    removeViewsAndLayers()
+
+    if !(self is UINavigationController) {
+      removeChildViewControllers()
+      removeViewsAndLayers()
+    }
+
     viewDidLoad()
     view.subviews.forEach { view in
       view.setNeedsLayout()


### PR DESCRIPTION
`UINavigationController`'s should not remove its internals when they are injected as that could mean that the `rootViewController` will be removed.