### PR TITLE
Feature view controller swizzling

### DIFF
--- a/Example/VaccineDemo/VaccineDemo/Sources/Controllers/DetailViewController.swift
+++ b/Example/VaccineDemo/VaccineDemo/Sources/Controllers/DetailViewController.swift
@@ -3,7 +3,6 @@ import Vaccine
 
 class DetailViewController: UIViewController {
   lazy var tableView = UITableView()
-  let imageSize: CGFloat = 128
   let dataSource: DetailDataSource
 
   private var layoutConstraints = [NSLayoutConstraint]()
@@ -35,6 +34,7 @@ class DetailViewController: UIViewController {
     view.addSubview(tableView)
     dataSource.tableView = tableView
     tableView.backgroundColor = .white
+    tableView.rowHeight = 60
     tableView.dataSource = dataSource
     tableView.register(DetailTableViewCell.self,
                        forCellReuseIdentifier: DetailTableViewCell.reuseIdentifier)

--- a/README.md
+++ b/README.md
@@ -88,13 +88,21 @@ When the code gets injected, `applicationDidLoad` will be invoked. It cleans and
 
 Injecting view controllers is really where InjectionIII shines the most. Vaccine provides extensions to make this easy to setup and maintain. When injection notifications come in, Vaccine will filter out view controllers that do not fill the criteria for being reloaded. It checks if the current view controller belongs to a child view controller, if that turns out to be true, then it will reload the parent view controller to make sure that all necessary controllers are notified about the change.
 
+**Note**
+Vaccine also supports adding view controller injection using swizzling.
+This feature can be enabled by setting `swizzling` to `true` when loading the bundle.
+
+```swift
+Injection.load(..., swizzling: true)
+```
+
 When injecting a view controller, the following things will happen:
 
 - Removes the current injection observer
 - Remove views and layers
 - Invokes `viewDidLoad` to correctly set up your view controller again
 - Invokes layout related methods on all available subviews of the controller's view.
-- Invoke sizeToFit on all views that haven't received a size
+- Invoke `sizeToFit` on all views that haven't received a size
 
 What you need to do in your view controllers is to listen to the incoming notifications and deregister when it is time to deallocate. Registering should be done in `viewDidLoad` as the observer will temporarily be removed during injection.
 
@@ -176,6 +184,11 @@ github "zenangst/Vaccine"
 ## Author
 
 Christoffer Winterkvist, christoffer@winterkvist.com
+
+## Credits
+
+- [Vadym Markov](https://github.com/vadymmarkov) for giving inspiration to the swizzling feature. [[Source]](https://github.com/vadymmarkov/Fashion/blob/master/Sources/Shared/Swizzler.swift)   
+- [John Holdsworth](https://github.com/johnno1962/InjectionIII) for making runtime code injection possible.
 
 ## Contributing
 

--- a/Source/Shared/DispatchQueue.swift
+++ b/Source/Shared/DispatchQueue.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+extension DispatchQueue {
+  private  static var tokens = [String]()
+
+  class func once(token: String, closure: () -> Void) {
+    objc_sync_enter(self)
+    defer { objc_sync_exit(self) }
+
+    guard !tokens.contains(token) else { return }
+
+    tokens.append(token)
+    closure()
+  }
+}

--- a/Source/Shared/Injection.swift
+++ b/Source/Shared/Injection.swift
@@ -41,6 +41,10 @@ public class Injection {
     return "/Applications/InjectionIII.app/Contents/Resources"
   }
 
+  static var swizzleViewControllers: Bool = false {
+    didSet { if swizzleViewControllers { ViewController._swizzleViewControllers() } }
+  }
+
   /// Deteremins if the InjectionIII bundle is loaded.
   static var isLoaded: Bool {
     // Check if tests are running.
@@ -61,7 +65,7 @@ public class Injection {
   /// - Parameter closure: Optional closure that will be invoked after the bundle has been loaded.
   ///                      NOTE: Will not be invoked if bundled is not found.
   /// - Returns: An instance of `self` in order to make the function chainable.
-  @discardableResult public static func load(_ closure: (() -> Void)? = nil) -> Injection.Type {
+  @discardableResult public static func load(_ closure: (() -> Void)? = nil, swizzling: Bool = false) -> Injection.Type {
     guard !Injection.isLoaded else { return self }
 
     #if targetEnvironment(simulator)
@@ -76,8 +80,8 @@ public class Injection {
       #endif
     #endif
 
+    swizzleViewControllers = swizzling
     closure?()
-
     return self
   }
 

--- a/Source/Shared/Swizzling.swift
+++ b/Source/Shared/Swizzling.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+class Swizzling {
+  static func swizzle(_ cls: AnyClass, originalSelector: Selector, swizzledSelector: Selector) {
+    let originalMethod = class_getInstanceMethod(cls, originalSelector)
+    let swizzledMethod = class_getInstanceMethod(cls, swizzledSelector)
+    method_exchangeImplementations(originalMethod!, swizzledMethod!)
+  }
+}

--- a/Source/Shared/ViewController+Extensions.swift
+++ b/Source/Shared/ViewController+Extensions.swift
@@ -1,0 +1,24 @@
+#if os(macOS)
+  import Cocoa
+#else
+  import UIKit
+#endif
+
+extension ViewController {
+  public static func _swizzleViewControllers() {
+    #if DEBUG
+      DispatchQueue.once(token: "com.zenangst.Vaccine.swizzleViewControllers") {
+        let originalSelector = #selector(viewDidLoad)
+        let swizzledSelector = #selector(vaccine_viewDidLoad)
+        Swizzling.swizzle(ViewController.self,
+                          originalSelector: originalSelector,
+                          swizzledSelector: swizzledSelector)
+      }
+    #endif
+  }
+
+  @objc func vaccine_viewDidLoad() {
+    vaccine_viewDidLoad()
+    Injection.addViewController(self)
+  }
+}

--- a/Vaccine.podspec
+++ b/Vaccine.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Vaccine"
   s.summary          = "Make your apps immune to recompile-decease."
-  s.version          = "0.2.0"
+  s.version          = "0.3.0"
   s.homepage         = "https://github.com/zenangst/Vaccine"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Vaccine.xcodeproj/project.pbxproj
+++ b/Vaccine.xcodeproj/project.pbxproj
@@ -34,6 +34,15 @@
 		BD6F516B20B7D6BA001E113B /* Injection.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD6F516A20B7D6BA001E113B /* Injection.swift */; };
 		BD6F516C20B7D6BA001E113B /* Injection.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD6F516A20B7D6BA001E113B /* Injection.swift */; };
 		BD6F516D20B7D6BA001E113B /* Injection.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD6F516A20B7D6BA001E113B /* Injection.swift */; };
+		BD7242C720CFBE760006DCF7 /* Swizzling.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD7242C620CFBE760006DCF7 /* Swizzling.swift */; };
+		BD7242C820CFBE760006DCF7 /* Swizzling.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD7242C620CFBE760006DCF7 /* Swizzling.swift */; };
+		BD7242C920CFBE760006DCF7 /* Swizzling.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD7242C620CFBE760006DCF7 /* Swizzling.swift */; };
+		BD7242CB20CFBF080006DCF7 /* DispatchQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD7242CA20CFBF080006DCF7 /* DispatchQueue.swift */; };
+		BD7242CC20CFBF080006DCF7 /* DispatchQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD7242CA20CFBF080006DCF7 /* DispatchQueue.swift */; };
+		BD7242CD20CFBF080006DCF7 /* DispatchQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD7242CA20CFBF080006DCF7 /* DispatchQueue.swift */; };
+		BD7242CF20CFC0CB0006DCF7 /* ViewController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD7242CE20CFC0CB0006DCF7 /* ViewController+Extensions.swift */; };
+		BD7242D020CFC0CB0006DCF7 /* ViewController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD7242CE20CFC0CB0006DCF7 /* ViewController+Extensions.swift */; };
+		BD7242D120CFC0CB0006DCF7 /* ViewController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD7242CE20CFC0CB0006DCF7 /* ViewController+Extensions.swift */; };
 		BDEA432620C9216C00CF30A2 /* UIScreen+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEA432520C9216C00CF30A2 /* UIScreen+Extensions.swift */; };
 		BDEA432B20C921B600CF30A2 /* Device.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEA432A20C921B600CF30A2 /* Device.swift */; };
 		D284B1051F79038B00D94AF3 /* Vaccine.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D284B0FC1F79038B00D94AF3 /* Vaccine.framework */; };
@@ -89,6 +98,9 @@
 		BD6F516420B74455001E113B /* UIApplicationDelegateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIApplicationDelegateTests.swift; sourceTree = "<group>"; };
 		BD6F516720B74475001E113B /* ViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewControllerTests.swift; sourceTree = "<group>"; };
 		BD6F516A20B7D6BA001E113B /* Injection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Injection.swift; sourceTree = "<group>"; };
+		BD7242C620CFBE760006DCF7 /* Swizzling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Swizzling.swift; sourceTree = "<group>"; };
+		BD7242CA20CFBF080006DCF7 /* DispatchQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DispatchQueue.swift; sourceTree = "<group>"; };
+		BD7242CE20CFC0CB0006DCF7 /* ViewController+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Extensions.swift"; sourceTree = "<group>"; };
 		BDEA432520C9216C00CF30A2 /* UIScreen+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIScreen+Extensions.swift"; sourceTree = "<group>"; };
 		BDEA432A20C921B600CF30A2 /* Device.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Device.swift; sourceTree = "<group>"; };
 		D284B0FC1F79038B00D94AF3 /* Vaccine.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Vaccine.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -294,9 +306,12 @@
 		D5C6296E1C3A809D007F7B7C /* Shared */ = {
 			isa = PBXGroup;
 			children = (
+				BD7242CA20CFBF080006DCF7 /* DispatchQueue.swift */,
 				BD6F516A20B7D6BA001E113B /* Injection.swift */,
 				BD6AC87620B6D61B00CBE8BA /* NSObject+Extensions.swift */,
+				BD7242C620CFBE760006DCF7 /* Swizzling.swift */,
 				BD4B8C4920C860CB00836815 /* TypeAlias.swift */,
+				BD7242CE20CFC0CB0006DCF7 /* ViewController+Extensions.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -601,9 +616,12 @@
 			buildActionMask = 2147483647;
 			files = (
 				BD6F516D20B7D6BA001E113B /* Injection.swift in Sources */,
+				BD7242C920CFBE760006DCF7 /* Swizzling.swift in Sources */,
 				BD6AC87320B6D5C800CBE8BA /* UIApplicationDelegate+Extensions.swift in Sources */,
 				BD5FC7F420B80D8500A08D21 /* UIViewController+Extensions.swift in Sources */,
+				BD7242D120CFC0CB0006DCF7 /* ViewController+Extensions.swift in Sources */,
 				BD6AC87920B6D61B00CBE8BA /* NSObject+Extensions.swift in Sources */,
+				BD7242CD20CFBF080006DCF7 /* DispatchQueue.swift in Sources */,
 				BD4B8C4C20C860CB00836815 /* TypeAlias.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -634,10 +652,13 @@
 				BD6F516B20B7D6BA001E113B /* Injection.swift in Sources */,
 				BDEA432620C9216C00CF30A2 /* UIScreen+Extensions.swift in Sources */,
 				BD6AC87220B6D5C800CBE8BA /* UIApplicationDelegate+Extensions.swift in Sources */,
+				BD7242C720CFBE760006DCF7 /* Swizzling.swift in Sources */,
 				BD5FC7F320B80D8500A08D21 /* UIViewController+Extensions.swift in Sources */,
 				BD6AC87720B6D61B00CBE8BA /* NSObject+Extensions.swift in Sources */,
+				BD7242CF20CFC0CB0006DCF7 /* ViewController+Extensions.swift in Sources */,
 				BDEA432B20C921B600CF30A2 /* Device.swift in Sources */,
 				BD4B8C4A20C860CB00836815 /* TypeAlias.swift in Sources */,
+				BD7242CB20CFBF080006DCF7 /* DispatchQueue.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -660,9 +681,12 @@
 			buildActionMask = 2147483647;
 			files = (
 				BD6F516C20B7D6BA001E113B /* Injection.swift in Sources */,
+				BD7242C820CFBE760006DCF7 /* Swizzling.swift in Sources */,
 				BD592EB820B837BB006DE955 /* NSViewController+Extensions.swift in Sources */,
 				BD6AC87520B6D5ED00CBE8BA /* NSApplicationDelegate+Extensions.swift in Sources */,
+				BD7242D020CFC0CB0006DCF7 /* ViewController+Extensions.swift in Sources */,
 				BD6AC87820B6D61B00CBE8BA /* NSObject+Extensions.swift in Sources */,
+				BD7242CC20CFBF080006DCF7 /* DispatchQueue.swift in Sources */,
 				BD4B8C4B20C860CB00836815 /* TypeAlias.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
View Controller swizzling can be enabled when loading the InjectionIII bundle.

Example:
```swift
Injection.load(..., swizzling: true)
```