### PR TITLE
Improve handling of UITabBarControllers and UINavigationControllers

### DIFF
--- a/Source/iOS+tvOS/UIViewController+Extensions.swift
+++ b/Source/iOS+tvOS/UIViewController+Extensions.swift
@@ -14,7 +14,12 @@ import UIKit
 
     NotificationCenter.default.removeObserver(self)
 
-    if !(self is UINavigationController) {
+    switch self {
+    case let navigationController as UINavigationController:
+      break
+    case let tabBarController as UITabBarController:
+      tabBarController.setViewControllers([], animated: true)
+    default:
       removeChildViewControllers()
       removeViewsAndLayers()
     }

--- a/Vaccine.podspec
+++ b/Vaccine.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Vaccine"
   s.summary          = "Make your apps immune to recompile-decease."
-  s.version          = "0.3.3"
+  s.version          = "0.3.4"
   s.homepage         = "https://github.com/zenangst/Vaccine"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }


### PR DESCRIPTION
`UINavigationController` and `UITabBarController` should not remove their child view controllers as that empties out their view stacks. Instead, `UINavigationController` should opt out from that behavior and `UITabBarController` can set the view controllers using an empty array so that `viewDidLoad` will set up new view controllers.