### PR TITLE
Refactor view controller swizzling

### DIFF
--- a/Source/Shared/ViewController+Extensions.swift
+++ b/Source/Shared/ViewController+Extensions.swift
@@ -35,8 +35,8 @@ extension ViewController {
   public static func _swizzleViewControllers() {
     #if DEBUG
       DispatchQueue.once(token: "com.zenangst.Vaccine.swizzleViewControllers") {
-        let originalSelector = #selector(viewDidLoad)
-        let swizzledSelector = #selector(vaccine_viewDidLoad)
+        let originalSelector = #selector(loadView)
+        let swizzledSelector = #selector(vaccine_loadView)
         Swizzling.swizzle(ViewController.self,
                           originalSelector: originalSelector,
                           swizzledSelector: swizzledSelector)
@@ -44,8 +44,8 @@ extension ViewController {
     #endif
   }
 
-  @objc func vaccine_viewDidLoad() {
-    vaccine_viewDidLoad()
+  @objc func vaccine_loadView() {
+    vaccine_loadView()
     Injection.addViewController(self)
   }
 }

--- a/Source/Shared/ViewController+Extensions.swift
+++ b/Source/Shared/ViewController+Extensions.swift
@@ -6,10 +6,9 @@
 
 extension ViewController {
   func viewControllerWasInjected(_ notification: Notification) -> Bool {
-    if Injection.swizzleViewControllers { return true }
     if Injection.objectWasInjected(self, notification: notification) { return true }
     guard let object = Injection.object(from: notification) else {
-      return Injection.swizzleViewControllers
+      return false
     }
 
     var shouldRespondToInjection: Bool = false

--- a/Source/iOS+tvOS/UIViewController+Extensions.swift
+++ b/Source/iOS+tvOS/UIViewController+Extensions.swift
@@ -12,7 +12,9 @@ import UIKit
     guard Injection.isLoaded else { return }
     guard viewControllerWasInjected(notification) else { return }
 
-    NotificationCenter.default.removeObserver(self)
+    if !Injection.swizzleViewControllers {
+      NotificationCenter.default.removeObserver(self)
+    }
 
     switch self {
     case _ as UINavigationController:

--- a/Vaccine.podspec
+++ b/Vaccine.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Vaccine"
   s.summary          = "Make your apps immune to recompile-disease."
-  s.version          = "0.3.4"
+  s.version          = "0.3.5"
   s.homepage         = "https://github.com/zenangst/Vaccine"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }


### PR DESCRIPTION
This refactors the view controller swizzling to use `loadView` instead of `viewDidLoad`. This is to avoid recursion as `viewDidLoad` is triggered when new code is injected. When using view controller swizzling, the observer remains intact after running the `viewControllerWasInjected`. The motivation behind this change is to reduce the potential of having multiple listeners and has mentioned above, to reduce the potential for recursion.