### PR TITLE
Refactor Injection internals

### DIFF
--- a/Source/Shared/ViewController+Extensions.swift
+++ b/Source/Shared/ViewController+Extensions.swift
@@ -5,32 +5,6 @@
 #endif
 
 extension ViewController {
-  func viewControllerWasInjected(_ notification: Notification) -> Bool {
-    if Injection.objectWasInjected(self, notification: notification) { return true }
-    guard let object = Injection.object(from: notification) else {
-      return false
-    }
-
-    var shouldRespondToInjection: Bool = false
-
-    /// Check if parent view controller should be injected.
-    if !childViewControllers.isEmpty {
-      for childViewController in childViewControllers {
-        if object.classForCoder == childViewController.classForCoder {
-          shouldRespondToInjection = true
-          break
-        }
-      }
-    }
-
-    /// Check if object matches self.
-    if !shouldRespondToInjection {
-      shouldRespondToInjection = object.classForCoder == self.classForCoder
-    }
-
-    return shouldRespondToInjection
-  }
-
   public static func _swizzleViewControllers() {
     #if DEBUG
       DispatchQueue.once(token: "com.zenangst.Vaccine.swizzleViewControllers") {

--- a/Source/iOS+tvOS/UIViewController+Extensions.swift
+++ b/Source/iOS+tvOS/UIViewController+Extensions.swift
@@ -10,7 +10,7 @@ import UIKit
 
   private func viewDidLoadIfNeeded(_ notification: Notification) {
     guard Injection.isLoaded else { return }
-    guard viewControllerWasInjected(notification) else { return }
+    guard Injection.viewControllerWasInjected(self, in: notification) else { return }
 
     if !Injection.swizzleViewControllers {
       NotificationCenter.default.removeObserver(self)

--- a/Source/macOS/NSViewController+Extensions.swift
+++ b/Source/macOS/NSViewController+Extensions.swift
@@ -3,7 +3,7 @@ import Cocoa
 @objc public extension NSViewController {
   private func viewDidLoadIfNeeded(_ notification: Notification) {
     guard Injection.isLoaded else { return }
-    guard viewControllerWasInjected(notification) else { return }
+    guard Injection.viewControllerWasInjected(self, in: notification) else { return }
 
     NotificationCenter.default.removeObserver(self)
     removeChildViewControllers()

--- a/Tests/Shared/InjectionTests.swift
+++ b/Tests/Shared/InjectionTests.swift
@@ -24,6 +24,6 @@ class InjectionTests: XCTestCase {
   func testInjectionValidation() {
     let object = MockedObject()
     let notification = Notification(name: Notification.Name(rawValue: "MockedNotification"), object: object, userInfo: nil)
-    XCTAssertTrue(Injection.objectWasInjected(object, notification: notification))
+    XCTAssertTrue(Injection.objectWasInjected(object, in: notification))
   }
 }

--- a/Vaccine.podspec
+++ b/Vaccine.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Vaccine"
   s.summary          = "Make your apps immune to recompile-disease."
-  s.version          = "0.3.5"
+  s.version          = "0.3.6"
   s.homepage         = "https://github.com/zenangst/Vaccine"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }


### PR DESCRIPTION
This moves the implementation of `viewControllerWasInjected` to `Injection` class.