### PR TITLE
Fix bundle not being loaded on macOS

### DIFF
--- a/Source/Shared/Injection.swift
+++ b/Source/Shared/Injection.swift
@@ -76,7 +76,7 @@ public class Injection {
       #endif
     #else
       #if os(macOS)
-        _ = Bundle(path: "\(Injection.resourcePath)/macOSInjection.bundle")
+        _ = Bundle(path: "\(Injection.resourcePath)/macOSInjection.bundle")?.load()
       #endif
     #endif
 

--- a/Source/macOS/NSApplicationDelegate+Extensions.swift
+++ b/Source/macOS/NSApplicationDelegate+Extensions.swift
@@ -4,7 +4,7 @@ public extension NSApplicationDelegate {
   func loadInjection(_ closure: (() -> Void)? = nil) {
     guard !Injection.isLoaded else { return }
 
-    _ = Bundle(path: "/Applications/InjectionIII.app/Contents/Resources/macOSInjection.bundle")
+    _ = Bundle(path: "/Applications/InjectionIII.app/Contents/Resources/macOSInjection.bundle")?.load()
 
     closure?()
   }

--- a/Vaccine.podspec
+++ b/Vaccine.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Vaccine"
   s.summary          = "Make your apps immune to recompile-disease."
-  s.version          = "0.4.1"
+  s.version          = "0.4.2"
   s.homepage         = "https://github.com/zenangst/Vaccine"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }


### PR DESCRIPTION
This PR fixes an oversight on macOS target. The bundle was never loaded into memory.