### PR TITLE
Feature swizzling for table and collection views

### DIFF
--- a/Source/Shared/CollectionView+Extensions.swift
+++ b/Source/Shared/CollectionView+Extensions.swift
@@ -17,9 +17,11 @@ public extension CollectionView {
     #endif
   }
 
-  @objc func vaccine_setDataSource(_ dataSource: CollectionViewDataSource) {
-    self.vaccine_setDataSource(dataSource)
-    addInjection(with: #selector(vaccine_datasource_injected))
+  @objc func vaccine_setDataSource(_ newDataSource: CollectionViewDataSource?) {
+    if dataSource == nil && newDataSource != nil {
+      addInjection(with: #selector(vaccine_datasource_injected))
+    }
+    self.vaccine_setDataSource(newDataSource)
   }
 
   @objc func vaccine_datasource_injected(_ notification: Notification) {

--- a/Source/Shared/CollectionView+Extensions.swift
+++ b/Source/Shared/CollectionView+Extensions.swift
@@ -1,0 +1,30 @@
+#if os(macOS)
+import Cocoa
+#else
+import UIKit
+#endif
+
+public extension CollectionView {
+  static func _swizzleCollectionViews() {
+    #if DEBUG
+    DispatchQueue.once(token: "com.zenangst.Vaccine.swizzleCollectionViews") {
+      let originalSelector = #selector(setter: CollectionView.dataSource)
+      let swizzledSelector = #selector(CollectionView.vaccine_setDataSource(_:))
+      Swizzling.swizzle(UICollectionView.self,
+                        originalSelector: originalSelector,
+                        swizzledSelector: swizzledSelector)
+    }
+    #endif
+  }
+
+  @objc func vaccine_setDataSource(_ dataSource: CollectionViewDataSource) {
+    self.vaccine_setDataSource(dataSource)
+    addInjection(with: #selector(vaccine_datasource_injected))
+  }
+
+  @objc func vaccine_datasource_injected(_ notification: Notification) {
+    guard let dataSource = dataSource else { return }
+    guard Injection.objectWasInjected(dataSource, in: notification) else { return }
+    reloadData()
+  }
+}

--- a/Source/Shared/Injection.swift
+++ b/Source/Shared/Injection.swift
@@ -61,6 +61,14 @@ public class Injection {
     didSet { if swizzleViews { View._swizzleViews() } }
   }
 
+  static var swizzleCollectionViews: Bool = false {
+    didSet { if swizzleTableViews { CollectionView._swizzleCollectionViews() } }
+  }
+
+  static var swizzleTableViews: Bool = false {
+    didSet { if swizzleTableViews { TableView._swizzleTableViews() } }
+  }
+
   static var swizzleViewControllers: Bool = false {
     didSet { if swizzleViewControllers { ViewController._swizzleViewControllers() } }
   }
@@ -96,6 +104,8 @@ public class Injection {
 
     swizzleViewControllers = swizzling
     swizzleViews = swizzling
+    swizzleTableViews = swizzling
+    swizzleCollectionViews = swizzling
     closure?()
     return self
   }

--- a/Source/Shared/TableView+Extensions.swift
+++ b/Source/Shared/TableView+Extensions.swift
@@ -17,9 +17,11 @@ public extension TableView {
     #endif
   }
 
-  @objc func vaccine_setDataSource(_ dataSource: TableViewDataSource) {
+  @objc func vaccine_setDataSource(_ newDataSource: TableViewDataSource?) {
+    if dataSource == nil && newDataSource != nil {
+      addInjection(with: #selector(vaccine_datasource_injected))
+    }
     self.vaccine_setDataSource(dataSource)
-    addInjection(with: #selector(vaccine_datasource_injected))
   }
 
   @objc func vaccine_datasource_injected(_ notification: Notification) {

--- a/Source/Shared/TableView+Extensions.swift
+++ b/Source/Shared/TableView+Extensions.swift
@@ -1,0 +1,30 @@
+#if os(macOS)
+import Cocoa
+#else
+import UIKit
+#endif
+
+public extension TableView {
+  static func _swizzleTableViews() {
+    #if DEBUG
+    DispatchQueue.once(token: "com.zenangst.Vaccine.swizzleTableViews") {
+      let originalSelector = #selector(setter: TableView.dataSource)
+      let swizzledSelector = #selector(TableView.vaccine_setDataSource(_:))
+      Swizzling.swizzle(TableView.self,
+                        originalSelector: originalSelector,
+                        swizzledSelector: swizzledSelector)
+    }
+    #endif
+  }
+
+  @objc func vaccine_setDataSource(_ dataSource: TableViewDataSource) {
+    self.vaccine_setDataSource(dataSource)
+    addInjection(with: #selector(vaccine_datasource_injected))
+  }
+
+  @objc func vaccine_datasource_injected(_ notification: Notification) {
+    guard let dataSource = dataSource else { return }
+    guard Injection.objectWasInjected(dataSource, in: notification) else { return }
+    reloadData()
+  }
+}

--- a/Source/Shared/TypeAlias.swift
+++ b/Source/Shared/TypeAlias.swift
@@ -1,9 +1,17 @@
 #if os(macOS)
-  import Cocoa
-  public typealias ViewController = NSViewController
-  public typealias View = NSView
+import Cocoa
+public typealias CollectionView = NSCollectionView
+public typealias CollectionViewDataSource = NSCollectionViewDataSource
+public typealias TableView = NSTableView
+public typealias TableViewDataSource = NSTableViewDataSource
+public typealias View = NSView
+public typealias ViewController = NSViewController
 #else
-  import UIKit
-  public typealias ViewController = UIViewController
-  public typealias View = UIView
+import UIKit
+public typealias CollectionView = UICollectionView
+public typealias CollectionViewDataSource = UICollectionViewDataSource
+public typealias TableView = UITableView
+public typealias TableViewDataSource = UITableViewDataSource
+public typealias View = UIView
+public typealias ViewController = UIViewController
 #endif

--- a/Source/Shared/View+Extensions.swift
+++ b/Source/Shared/View+Extensions.swift
@@ -18,7 +18,6 @@ extension View {
                         swizzledSelector: swizzledSelector)
     }
     #endif
-
   }
 
   @objc public convenience init(vaccineFrame frame: Rect) {

--- a/Vaccine.podspec
+++ b/Vaccine.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Vaccine"
   s.summary          = "Make your apps immune to recompile-disease."
-  s.version          = "0.5.0"
+  s.version          = "0.6.0"
   s.homepage         = "https://github.com/zenangst/Vaccine"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Vaccine.xcodeproj/project.pbxproj
+++ b/Vaccine.xcodeproj/project.pbxproj
@@ -7,6 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		BD2C456E21385A2D00C17BD6 /* CollectionView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2C456D21385A2D00C17BD6 /* CollectionView+Extensions.swift */; };
+		BD2C456F21385A2D00C17BD6 /* CollectionView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2C456D21385A2D00C17BD6 /* CollectionView+Extensions.swift */; };
+		BD2C457121385AD900C17BD6 /* TableView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2C457021385AD900C17BD6 /* TableView+Extensions.swift */; };
+		BD2C457221385AD900C17BD6 /* TableView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2C457021385AD900C17BD6 /* TableView+Extensions.swift */; };
+		BD2C457321385BAD00C17BD6 /* CollectionView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2C456D21385A2D00C17BD6 /* CollectionView+Extensions.swift */; };
+		BD2C457421385BB600C17BD6 /* TableView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2C457021385AD900C17BD6 /* TableView+Extensions.swift */; };
 		BD2F6E6420C93B3200621BC8 /* UIScreenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2F6E6320C93B3200621BC8 /* UIScreenTests.swift */; };
 		BD4B8C4A20C860CB00836815 /* TypeAlias.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4B8C4920C860CB00836815 /* TypeAlias.swift */; };
 		BD4B8C4B20C860CB00836815 /* TypeAlias.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4B8C4920C860CB00836815 /* TypeAlias.swift */; };
@@ -83,6 +89,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		BD2C456D21385A2D00C17BD6 /* CollectionView+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CollectionView+Extensions.swift"; sourceTree = "<group>"; };
+		BD2C457021385AD900C17BD6 /* TableView+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TableView+Extensions.swift"; sourceTree = "<group>"; };
 		BD2F6E6320C93B3200621BC8 /* UIScreenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIScreenTests.swift; sourceTree = "<group>"; };
 		BD4B8C4920C860CB00836815 /* TypeAlias.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeAlias.swift; sourceTree = "<group>"; };
 		BD592EB720B837BB006DE955 /* NSViewController+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSViewController+Extensions.swift"; sourceTree = "<group>"; };
@@ -298,10 +306,12 @@
 		D5C6296E1C3A809D007F7B7C /* Shared */ = {
 			isa = PBXGroup;
 			children = (
+				BD2C456D21385A2D00C17BD6 /* CollectionView+Extensions.swift */,
 				BD7242CA20CFBF080006DCF7 /* DispatchQueue.swift */,
 				BD6F516A20B7D6BA001E113B /* Injection.swift */,
 				BD6AC87620B6D61B00CBE8BA /* NSObject+Extensions.swift */,
 				BD7242C620CFBE760006DCF7 /* Swizzling.swift */,
+				BD2C457021385AD900C17BD6 /* TableView+Extensions.swift */,
 				BD4B8C4920C860CB00836815 /* TypeAlias.swift */,
 				BDFC75872135307B001610EC /* View+Extensions.swift */,
 				BD7242CE20CFC0CB0006DCF7 /* ViewController+Extensions.swift */,
@@ -569,10 +579,12 @@
 			files = (
 				BD6F516D20B7D6BA001E113B /* Injection.swift in Sources */,
 				BDFC758A2135307B001610EC /* View+Extensions.swift in Sources */,
+				BD2C456F21385A2D00C17BD6 /* CollectionView+Extensions.swift in Sources */,
 				BD7242C920CFBE760006DCF7 /* Swizzling.swift in Sources */,
 				BD6AC87320B6D5C800CBE8BA /* UIApplicationDelegate+Extensions.swift in Sources */,
 				BD5FC7F420B80D8500A08D21 /* UIViewController+Extensions.swift in Sources */,
 				BD7242D120CFC0CB0006DCF7 /* ViewController+Extensions.swift in Sources */,
+				BD2C457221385AD900C17BD6 /* TableView+Extensions.swift in Sources */,
 				BD6AC87920B6D61B00CBE8BA /* NSObject+Extensions.swift in Sources */,
 				BD7242CD20CFBF080006DCF7 /* DispatchQueue.swift in Sources */,
 				BD4B8C4C20C860CB00836815 /* TypeAlias.swift in Sources */,
@@ -603,6 +615,8 @@
 				BD5FC7F320B80D8500A08D21 /* UIViewController+Extensions.swift in Sources */,
 				BD6AC87720B6D61B00CBE8BA /* NSObject+Extensions.swift in Sources */,
 				BD7242CF20CFC0CB0006DCF7 /* ViewController+Extensions.swift in Sources */,
+				BD2C457121385AD900C17BD6 /* TableView+Extensions.swift in Sources */,
+				BD2C456E21385A2D00C17BD6 /* CollectionView+Extensions.swift in Sources */,
 				BDEA432B20C921B600CF30A2 /* Device.swift in Sources */,
 				BD4B8C4A20C860CB00836815 /* TypeAlias.swift in Sources */,
 				BD7242CB20CFBF080006DCF7 /* DispatchQueue.swift in Sources */,
@@ -629,10 +643,12 @@
 			files = (
 				BD6F516C20B7D6BA001E113B /* Injection.swift in Sources */,
 				BDFC75892135307B001610EC /* View+Extensions.swift in Sources */,
+				BD2C457321385BAD00C17BD6 /* CollectionView+Extensions.swift in Sources */,
 				BD7242C820CFBE760006DCF7 /* Swizzling.swift in Sources */,
 				BD592EB820B837BB006DE955 /* NSViewController+Extensions.swift in Sources */,
 				BD6AC87520B6D5ED00CBE8BA /* NSApplicationDelegate+Extensions.swift in Sources */,
 				BD7242D020CFC0CB0006DCF7 /* ViewController+Extensions.swift in Sources */,
+				BD2C457421385BB600C17BD6 /* TableView+Extensions.swift in Sources */,
 				BD6AC87820B6D61B00CBE8BA /* NSObject+Extensions.swift in Sources */,
 				BD7242CC20CFBF080006DCF7 /* DispatchQueue.swift in Sources */,
 				BD4B8C4B20C860CB00836815 /* TypeAlias.swift in Sources */,


### PR DESCRIPTION
This PR adds swizzled injection for collection and table view data source.
It dramatically reduces the amount of `Vaccine` imports that you need in your project.

Collection and table views will now get automatic injection as `setDataSource` will be swizzled
at run-time. It adds an observer for the regular injection notification and validates that it was the
data source that is a part of the notification as it comes in. The observer is added to collection and
table views but it will respond to the data sources being injected. That way, anytime you make a change to the data source, the collection or table view will reload its contents... and voila, live reloading.