### PR TITLE
Fix bug when trying to set data source

### DIFF
--- a/Source/Shared/TableView+Extensions.swift
+++ b/Source/Shared/TableView+Extensions.swift
@@ -21,7 +21,7 @@ public extension TableView {
     if dataSource == nil && newDataSource != nil {
       addInjection(with: #selector(vaccine_datasource_injected))
     }
-    self.vaccine_setDataSource(dataSource)
+    self.vaccine_setDataSource(newDataSource)
   }
 
   @objc func vaccine_datasource_injected(_ notification: Notification) {

--- a/Vaccine.podspec
+++ b/Vaccine.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Vaccine"
   s.summary          = "Make your apps immune to recompile-disease."
-  s.version          = "0.6.0"
+  s.version          = "0.6.1"
   s.homepage         = "https://github.com/zenangst/Vaccine"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }


### PR DESCRIPTION
Fixes bug that data source is never set to the table view. It should use `newDataSource` as `dataSource` is the old value. The previous implementation would lead to the data source never being set on the table view.