### PR TITLE
Suppress warning from Selector invocation

### DIFF
--- a/Source/Shared/View+Extensions.swift
+++ b/Source/Shared/View+Extensions.swift
@@ -29,9 +29,13 @@ extension View {
   }
 
   @objc func vaccine_view_injected(_ notification: Notification) {
-    let selector = Selector("loadView")
+    let selector = _Selector("loadView")
     if responds(to: selector), Injection.objectWasInjected(self, in: notification) {
       perform(selector)
     }
+  }
+
+  private func _Selector(_ string: String) -> Selector {
+    return Selector(string)
   }
 }

--- a/Vaccine.podspec
+++ b/Vaccine.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Vaccine"
   s.summary          = "Make your apps immune to recompile-disease."
-  s.version          = "0.6.1"
+  s.version          = "0.6.2"
   s.homepage         = "https://github.com/zenangst/Vaccine"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }


### PR DESCRIPTION
This fixes a warning about using `Selector` instead of #selector