### PR TITLE
Improve the search pattern in isLoaded property

### DIFF
--- a/Source/Shared/Injection.swift
+++ b/Source/Shared/Injection.swift
@@ -73,19 +73,26 @@ public class Injection {
     didSet { if swizzleViewControllers { ViewController._swizzleViewControllers() } }
   }
 
-  /// Deteremins if the InjectionIII bundle is loaded.
+  /// Deteremins if the InjectionIII bundle is loaded by searching all loaded bundles.
   static var isLoaded: Bool {
     // Check if tests are running.
     if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil {
       return true
     }
 
-    return !Bundle.allBundles.filter {
-      $0.bundleURL
+    // Search for injection in the loaded bundles.
+    var result: Bool = false
+    for bundle in Bundle.allBundles {
+      let url = bundle.bundleURL
         .lastPathComponent
         .lowercased()
-        .range(of: "injection") != nil }
-      .isEmpty
+      if url.range(of: "injection.bundle") != nil {
+        result = true
+        break
+      }
+    }
+
+    return result
   }
 
   /// Load the InjectionIII bundle.

--- a/Source/Shared/Injection.swift
+++ b/Source/Shared/Injection.swift
@@ -73,7 +73,7 @@ public class Injection {
     didSet { if swizzleViewControllers { ViewController._swizzleViewControllers() } }
   }
 
-  /// Deteremins if the InjectionIII bundle is loaded by searching all loaded bundles.
+  /// Determines if the InjectionIII bundle is loaded by searching all loaded bundles.
   static var isLoaded: Bool {
     // Check if tests are running.
     if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil {

--- a/Vaccine.podspec
+++ b/Vaccine.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Vaccine"
   s.summary          = "Make your apps immune to recompile-disease."
-  s.version          = "0.6.2"
+  s.version          = "0.6.3"
   s.homepage         = "https://github.com/zenangst/Vaccine"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }


### PR DESCRIPTION
`Injection.isLoaded` is now more precise as it includes `.bundle` in the range that is searches for.
Before this change, it might skip to load the bundle if any other bundle included injection in its name.