### PR TITLE
Feature animated injection transitions

### DIFF
--- a/Source/Shared/Injection.swift
+++ b/Source/Shared/Injection.swift
@@ -73,6 +73,8 @@ public class Injection {
     didSet { if swizzleViewControllers { ViewController._swizzleViewControllers() } }
   }
 
+  static var animations: Bool = false
+
   /// Determines if the InjectionIII bundle is loaded by searching all loaded bundles.
   static var isLoaded: Bool {
     // Check if tests are running.
@@ -100,7 +102,9 @@ public class Injection {
   /// - Parameter closure: Optional closure that will be invoked after the bundle has been loaded.
   ///                      NOTE: Will not be invoked if bundled is not found.
   /// - Returns: An instance of `self` in order to make the function chainable.
-  @discardableResult public static func load(_ closure: (() -> Void)? = nil, swizzling: Bool = false) -> Injection.Type {
+  @discardableResult public static func load(_ closure: (() -> Void)? = nil,
+                                             swizzling: Bool = false,
+                                             animations: Bool = false) -> Injection.Type {
     guard !Injection.isLoaded else { return self }
 
     #if targetEnvironment(simulator)
@@ -113,6 +117,7 @@ public class Injection {
     swizzleViews = swizzling
     swizzleTableViews = swizzling
     swizzleCollectionViews = swizzling
+    self.animations = animations
     closure?()
     return self
   }

--- a/Source/Shared/Injection.swift
+++ b/Source/Shared/Injection.swift
@@ -104,7 +104,7 @@ public class Injection {
   /// - Returns: An instance of `self` in order to make the function chainable.
   @discardableResult public static func load(_ closure: (() -> Void)? = nil,
                                              swizzling: Bool = false,
-                                             animations: Bool = false) -> Injection.Type {
+                                             animations: Bool = true) -> Injection.Type {
     guard !Injection.isLoaded else { return self }
 
     #if targetEnvironment(simulator)

--- a/Source/Shared/View+Extensions.swift
+++ b/Source/Shared/View+Extensions.swift
@@ -31,7 +31,18 @@ extension View {
   @objc func vaccine_view_injected(_ notification: Notification) {
     let selector = _Selector("loadView")
     if responds(to: selector), Injection.objectWasInjected(self, in: notification) {
-      perform(selector)
+      #if os(macOS)
+        self.perform(selector)
+      #else
+        guard Injection.animations else { self.perform(selector); return }
+
+        let options: UIViewAnimationOptions = [.allowAnimatedContent,
+                                               .beginFromCurrentState,
+                                               .layoutSubviews]
+        UIView.animate(withDuration: 0.3, delay: 0.0, options: options, animations: {
+          self.perform(selector)
+        }, completion: nil)
+      #endif
     }
   }
 

--- a/Source/iOS+tvOS/UIViewController+Extensions.swift
+++ b/Source/iOS+tvOS/UIViewController+Extensions.swift
@@ -1,6 +1,7 @@
 import UIKit
 
 @objc public extension UIViewController {
+  /// Removes all child view controllers.
   private func removeChildViewControllers() {
     #if swift(>=4.2)
     children.forEach { controller in
@@ -17,15 +18,27 @@ import UIKit
     #endif
   }
 
-  private func lockScreenUpdates(_ shouldLock: Bool, scrollViews: [UIScrollView: CGPoint]) {
+  /// Lock screen updates using a `CATransaction`.
+  ///
+  /// - Parameter shouldLock: A boolean value indicating if the method should
+  ///                         be invoked or not. This is determined by the
+  ///                         amount of child view controllers in the controller.
+  private func lockScreenUpdates(_ shouldLock: Bool) {
     guard shouldLock else { return }
     CATransaction.begin()
     CATransaction.lock()
   }
 
-  private func unlockScreenUpdates(_ shouldUnlock: Bool, scrollViews: [UIScrollView: CGPoint]) {
+  /// Unlock screen updates using a `CATransaction`.
+  ///
+  /// - Parameters:
+  /// - Parameter shouldLock: A boolean value indicating if the method should
+  ///                         be invoked or not. This is determined by the
+  ///                         amount of child view controllers in the controller.
+  ///   - scrollViews: A dictionary of scroll views related to the view controller.
+  private func unlockScreenUpdates(_ shouldUnlock: Bool, scrollViews: [UIScrollView]) {
     guard shouldUnlock else { return }
-    scrollViews.forEach { $0.key.contentOffset = $0.value }
+    syncOldScrollViews(scrollViews, with: indexScrollViews())
     let nearFuture = DispatchTime.now() + 0.3
     DispatchQueue.main.asyncAfter(deadline: nearFuture) {
       CATransaction.unlock()
@@ -33,51 +46,22 @@ import UIKit
     }
   }
 
+  /// Validate if the current class was injected by checking the contents
+  /// of the notification.
+  ///
+  /// - Parameter notification: A standard InjectionIII notification
   private func viewDidLoadIfNeeded(_ notification: Notification) {
     guard Injection.isLoaded else { return }
     guard Injection.viewControllerWasInjected(self, in: notification) else { return }
-
-    let options: UIViewAnimationOptions = [.allowAnimatedContent,
-                                           .beginFromCurrentState,
-                                           .layoutSubviews]
-
     if !Injection.swizzleViewControllers {
       NotificationCenter.default.removeObserver(self)
     }
 
-    if Injection.animations, let snapshot = self.view.snapshotView(afterScreenUpdates: false) {
-      let maskView = UIView()
-      maskView.frame.size = snapshot.frame.size
-      maskView.frame.origin.y = navigationController?.navigationBar.frame.maxY ?? 0
-      maskView.backgroundColor = .white
-      snapshot.mask = maskView
-      view.window?.addSubview(snapshot)
-      self.performCleanUp()
-      self.performCoreTasks()
-      UIView.animate(withDuration: 0.15, delay: 0.0, options: options, animations: {
-        snapshot.alpha = 0.0
-      }) { _ in
-        snapshot.removeFromSuperview()
-      }
-    } else {
-      self.performCleanUp()
-      self.performCoreTasks()
-    }
+    performInjection()
   }
 
+  /// Clean up view hierarchy by removing child view controllers, view and layers.
   private func performCleanUp() {
-    var scrollViews = [UIScrollView: CGPoint]()
-    if !Injection.animations {
-      defer {
-        unlockScreenUpdates(!scrollViews.isEmpty, scrollViews: scrollViews)
-      }
-      lockScreenUpdates(!scrollViews.isEmpty, scrollViews: scrollViews)
-    }
-
-    for case let scrollView as UIScrollView in view.subviews {
-      scrollViews[scrollView] = scrollView.contentOffset
-    }
-
     switch self {
     case _ as UINavigationController:
       break
@@ -89,7 +73,60 @@ import UIKit
     }
   }
 
-  private func performCoreTasks() {
+  /// Invoke all injection related methods in sequence.
+  /// If this method is invoked with animations enabled,
+  /// a snapshot of the current view will be created and
+  /// added to the applications window in order to nicely
+  /// transition to the new controller view state.
+  private func performInjection() {
+    let options: UIViewAnimationOptions = [.allowAnimatedContent,
+                                           .beginFromCurrentState,
+                                           .layoutSubviews]
+    if Injection.animations, let snapshot = self.view.snapshotView(afterScreenUpdates: false) {
+      let maskView = UIView()
+      maskView.frame.size = snapshot.frame.size
+      maskView.frame.origin.y = navigationController?.navigationBar.frame.maxY ?? 0
+      maskView.backgroundColor = .white
+      snapshot.mask = maskView
+      view.window?.addSubview(snapshot)
+      let oldScrollViews = indexScrollViews()
+      performCleanUp()
+      reloadUserInterface()
+      syncOldScrollViews(oldScrollViews, with: indexScrollViews())
+      UIView.animate(withDuration: 0.25, delay: 0.0, options: options, animations: {
+        snapshot.alpha = 0.0
+      }) { _ in
+        snapshot.removeFromSuperview()
+      }
+    } else {
+      let scrollViews = indexScrollViews()
+      lockScreenUpdates(!scrollViews.isEmpty)
+      performCleanUp()
+      reloadUserInterface()
+      unlockScreenUpdates(!scrollViews.isEmpty, scrollViews: scrollViews)
+    }
+  }
+
+  /// Sync two scroll views content offset if they are of the same type.
+  ///
+  /// - Parameters:
+  ///   - oldScrollViews: An array of scroll views from before the injection occured.
+  ///   - newScrollViews: An array of new scroll views after the injection occured.
+  private func syncOldScrollViews(_ oldScrollViews: [UIScrollView], with newScrollViews: [UIScrollView]) {
+    for (offset, scrollView) in newScrollViews.enumerated() {
+      if offset < oldScrollViews.count {
+        let oldScrollView = oldScrollViews[offset]
+        if type(of: scrollView) == type(of: oldScrollView) {
+          scrollView.contentOffset = oldScrollView.contentOffset
+        }
+      }
+    }
+  }
+
+  /// Will invoke `viewDidLoad` to run view controllers setup operations.
+  /// In addition, it will force all subview to layout and collection & table views
+  /// to reload. This is to make sure that we are displaying the latest changes.
+  private func reloadUserInterface() {
     viewDidLoad()
     view.subviews.forEach { view in
       view.setNeedsLayout()
@@ -105,6 +142,31 @@ import UIKit
     }
   }
 
+  /// Create an index of the content offsets for all underlying scroll views.
+  ///
+  /// - Returns: A dictionary of scroll views and their current origin.
+  private func indexScrollViews() -> [UIScrollView] {
+    var scrollViews = [UIScrollView]()
+    for case let scrollView as UIScrollView in view.subviews {
+      scrollViews.append(scrollView)
+    }
+
+    if let parentViewController = parent {
+      for case let scrollView as UIScrollView in parentViewController.view.subviews {
+        scrollViews.append(scrollView)
+      }
+    }
+
+    for childViewController in childViewControllers {
+      for case let scrollView as UIScrollView in childViewController.view.subviews {
+        scrollViews.append(scrollView)
+      }
+    }
+
+    return scrollViews
+  }
+
+  /// Removes all views and layers from a view.
   private func removeViewsAndLayers() {
     view.subviews.forEach {
       $0.removeFromSuperview()

--- a/Vaccine.podspec
+++ b/Vaccine.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Vaccine"
   s.summary          = "Make your apps immune to recompile-disease."
-  s.version          = "0.6.3"
+  s.version          = "0.7.0"
   s.homepage         = "https://github.com/zenangst/Vaccine"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }


### PR DESCRIPTION
This PR adds animations when view controllers and views are injected.
What this means is that for views, it will run the setup method (like `loadView`) with animations.
For view controllers, it will create a snapshot view and transition between that view and the new view state that gets injected.

This PR also refactors how content offsets is being restored between injections.

Animations are enabled by default but can be disabled by setting `animations` to `false` when loading the bundle.