### PR TITLE
Feature layout constraints deactivation by convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ For InjectionIII to work, you need to load the bundle located inside the applica
 ```swift
 // Loads the injection bundle and registers 
 // for injection notifications using `injected` selector.
-Injection.load(self.applicationDidLoad)
+Injection.load(then: applicationDidLoad)
          .add(observer: self, with: #selector(injected(_:)))
 ```
 
@@ -66,7 +66,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
   func application(_ application: UIApplication,
                    didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
-    Injection.load(self.applicationDidLoad).add(observer: self,
+                   Injection.load(then: applicationDidLoad).add(observer: self,
                                                 with: #selector(injected(_:)))
     return true
   }
@@ -92,11 +92,11 @@ When the code gets injected, `applicationDidLoad` will be invoked. It cleans and
 Injecting view controllers is really where InjectionIII shines the most. Vaccine provides extensions to make this easy to setup and maintain. When injection notifications come in, Vaccine will filter out view controllers that do not fill the criteria for being reloaded. It checks if the current view controller belongs to a child view controller, if that turns out to be true, then it will reload the parent view controller to make sure that all necessary controllers are notified about the change.
 
 **Note**
-Vaccine also supports adding view controller injection using swizzling.
-This feature can be enabled by setting `swizzling` to `true` when loading the bundle.
+Vaccine also supports adding injection using swizzling on views, view controllers and table and collection view data sources.
+This features is enabled by default but can be disabled by setting `swizzling` to `false` when loading the bundle.
 
 ```swift
-Injection.load(..., swizzling: true)
+Injection.load(then: ..., swizzling: false)
 ```
 
 When injecting a view controller, the following things will happen:
@@ -164,7 +164,7 @@ class CustomView: UIView {
     fatalError("init(coder:) has not been implemented")
   }
 
-  @objc func loadView() {
+  @objc private func loadView() {
     // Your code goes here.
   }
 }
@@ -175,7 +175,14 @@ creating an Xcode template for creating views.
 
 ## Auto layout constraints
 
-Adding additional constraints can quickly land you in a situation where your layout constraints are ambiguous. One way to tackle this issue is to gather all your views constraints into an array, and at the top of your setup method, you simply set these constraints to be deactivated. That way you can add additional constraints by continuing to inject, and the latest pair are the only ones that will be active and in use.
+Adding additional constraints can quickly land you in a situation where your layout constraints are ambiguous. 
+One way to tackle this issue is to gather all your views constraints into an array, and at the top of your setup method, 
+you simply set these constraints to be deactivated. That way you can add additional constraints by continuing to inject, 
+and the latest pair are the only ones that will be active and in use.
+
+When using `swizzling`, the framework will try and resolve the `layoutConstraints` from your view and deactivate them in order to avoid
+conflict with any new constraints that you may apply in your `loadView()` method. Which means that you can remove the call to `NSLayoutConstraint`
+to deactivate the current constraints.
 
 ```swift
 class CustomView: UIView {

--- a/Source/Shared/Injection.swift
+++ b/Source/Shared/Injection.swift
@@ -97,13 +97,20 @@ public class Injection {
     return result
   }
 
-  /// Load the InjectionIII bundle.
+  /// Load the InjectionIII bundle and optionally perform post actions when the bundle
+  /// is finished loading. The handler is called even if the bundle cannot be found.
   ///
-  /// - Parameter closure: Optional closure that will be invoked after the bundle has been loaded.
-  ///                      NOTE: Will not be invoked if bundled is not found.
+  /// - Parameters:
+  ///   - handler: Optional closure that will be invoked after the bundle has been loaded.
+  ///   - swizzling: Determines if swizzling should be applied, defaults to `true`.
+  ///   - animations: Determines if animations should be used for view and view controller injections.
+  ///                 Defaults to `true`
   /// - Returns: An instance of `self` in order to make the function chainable.
-  @discardableResult public static func load(_ closure: (() -> Void)? = nil,
-                                             swizzling: Bool = false,
+  ///
+  /// - Note: The bundle will only load if the application is running in the simulator.
+  ///         Swizzling is only allowed from applications that have the `DEBUG` flag set.
+  @discardableResult public static func load(then handler: (() -> Void)? = nil,
+                                             swizzling: Bool = true,
                                              animations: Bool = true) -> Injection.Type {
     guard !Injection.isLoaded else { return self }
 
@@ -118,7 +125,7 @@ public class Injection {
     swizzleTableViews = swizzling
     swizzleCollectionViews = swizzling
     self.animations = animations
-    closure?()
+    handler?()
     return self
   }
 

--- a/Source/Shared/TypeAlias.swift
+++ b/Source/Shared/TypeAlias.swift
@@ -4,6 +4,26 @@ public typealias CollectionView = NSCollectionView
 public typealias CollectionViewDataSource = NSCollectionViewDataSource
 public typealias TableView = NSTableView
 public typealias TableViewDataSource = NSTableViewDataSource
+
+/// A view extension that is used to add swizzling of the `init(_ frame: CGRect)` in order
+/// to automatically subscribe to injection notifications. When a view is injected,
+/// the notification from `InjectionIII` will be validate to check if the current class
+/// was injected or not. It does this by looking at the payload of the notification,
+/// more precisely it examines the `.object` of the notification.
+///
+/// If the view that gets injected has a method called `loadView`, this method will be
+/// invoked when the new class is injected. That way the setup for the view is perform
+/// and the new changes will appear inside your view.
+///
+/// - Note:
+/// Swizzling only works if the application is built with the variable `DEBUG` being set.
+/// It has no effect when running the application in production.
+///
+/// For `loadView` to work, it needs to be visible inside of Objective-C runtime.
+/// You will have to annotate this function with `@objc` in order for injection
+/// to perform the selector.
+///
+///     @objc private func loadView() {}
 public typealias View = NSView
 public typealias ViewController = NSViewController
 #else
@@ -12,6 +32,25 @@ public typealias CollectionView = UICollectionView
 public typealias CollectionViewDataSource = UICollectionViewDataSource
 public typealias TableView = UITableView
 public typealias TableViewDataSource = UITableViewDataSource
+/// A view extension that is used to add swizzling of the `init(_ frame: CGRect)` in order
+/// to automatically subscribe to injection notifications. When a view is injected,
+/// the notification from `InjectionIII` will be validate to check if the current class
+/// was injected or not. It does this by looking at the payload of the notification,
+/// more precisely it examines the `.object` of the notification.
+///
+/// If the view that gets injected has a method called `loadView`, this method will be
+/// invoked when the new class is injected. That way the setup for the view is perform
+/// and the new changes will appear inside your view.
+///
+/// - Note:
+/// Swizzling only works if the application is built with the variable `DEBUG` being set.
+/// It has no effect when running the application in production.
+///
+/// For `loadView` to work, it needs to be visible inside of Objective-C runtime.
+/// You will have to annotate this function with `@objc` in order for injection
+/// to perform the selector.
+///
+///     @objc private func loadView() {}
 public typealias View = UIView
 public typealias ViewController = UIViewController
 #endif

--- a/Source/Shared/View+Extensions.swift
+++ b/Source/Shared/View+Extensions.swift
@@ -7,7 +7,7 @@ public typealias Rect = CGRect
 #endif
 
 extension View {
-  // Swizzle initializers for views if application is compiled in debug mode.
+  /// Swizzle initializers for views if application is compiled in debug mode.
   static func _swizzleViews() {
     #if DEBUG
     DispatchQueue.once(token: "com.zenangst.Vaccine.swizzleViews") {
@@ -20,6 +20,10 @@ extension View {
     #endif
   }
 
+  /// Swizzled init method for view.
+  /// This method is used to add a responder for InjectionIII notifications.
+  ///
+  /// - Parameter frame: The frame rectangle for the view, measured in points.
   @objc public convenience init(vaccineFrame frame: Rect) {
     self.init(vaccineFrame: frame)
     let selector = #selector(View.vaccine_view_injected(_:))
@@ -28,13 +32,22 @@ extension View {
     }
   }
 
+  /// Respond to InjectionIII notifications.
+  /// The notification will be validate to verify that the current view
+  /// was injected. If the view responds to `loadView`, that method
+  /// will be invoked after the layout constraints have been deactivated.
+  /// See `invalidateIfNeededLayoutConstraints` for more information about
+  /// how layout constraints are handled via convention.
+  ///
+  /// - Parameter notification: An InjectionIII notification.
   @objc func vaccine_view_injected(_ notification: Notification) {
     let selector = _Selector("loadView")
     if responds(to: selector), Injection.objectWasInjected(self, in: notification) {
+      invalidateIfNeededLayoutConstraints()
       #if os(macOS)
-        self.perform(selector)
+        self.perform(loadViewSelector)
       #else
-        guard Injection.animations else { self.perform(selector); return }
+        guard Injection.animations else { perform(selector); return }
 
         let options: UIViewAnimationOptions = [.allowAnimatedContent,
                                                .beginFromCurrentState,
@@ -46,7 +59,21 @@ extension View {
     }
   }
 
+  /// Create selector using string. This method is meant to silence the warning
+  /// that occure when trying to use `Selector` instead of `#selector`.
+  ///
+  /// - Parameter string: The key that should be used as selector.
+  /// - Returns: A selector constructed from the given string parameter.
   private func _Selector(_ string: String) -> Selector {
     return Selector(string)
+  }
+
+  /// Invalidate layout constraints if `.layoutConstraints` can be resolved.
+  private func invalidateIfNeededLayoutConstraints() {
+    let key = "layoutConstraints"
+    let selector = _Selector(key)
+    if responds(to: selector), let layoutConstraints = value(forKey: key) as? [NSLayoutConstraint] {
+      NSLayoutConstraint.deactivate(layoutConstraints)
+    }
   }
 }

--- a/Source/Shared/View+Extensions.swift
+++ b/Source/Shared/View+Extensions.swift
@@ -45,7 +45,7 @@ extension View {
     if responds(to: selector), Injection.objectWasInjected(self, in: notification) {
       invalidateIfNeededLayoutConstraints()
       #if os(macOS)
-        self.perform(loadViewSelector)
+        self.perform(selector)
       #else
         guard Injection.animations else { perform(selector); return }
 

--- a/Vaccine.podspec
+++ b/Vaccine.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Vaccine"
   s.summary          = "Make your apps immune to recompile-disease."
-  s.version          = "0.7.0"
+  s.version          = "0.8.0"
   s.homepage         = "https://github.com/zenangst/Vaccine"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }


### PR DESCRIPTION
- Improves the `load` signature by adding `then` label for the closure. It improves readability at the call-site.
- Swizzling and animations are now defaults set to `true` when loading the injection bundle.
- When a view is injected, `.layoutConstraints` will be deactivated before `loadView` is invoked. This saves you from adding it to your code-base.
- Updates the README to include the latest changes to the framework.

Loading the application bundle now looks like this:
```swift
Injection.load(then: loadApp)
```