### PR TITLE
Feature/window transitions extension

### DIFF
--- a/Source/iOS+tvOS/UIApplicationDelegate+Extensions.swift
+++ b/Source/iOS+tvOS/UIApplicationDelegate+Extensions.swift
@@ -1,18 +1,6 @@
 import UIKit
 
 public extension UIApplicationDelegate {
-  func loadInjection(_ closure: (() -> Void)? = nil) {
-    guard !Injection.isLoaded else { return }
-
-    #if targetEnvironment(simulator)
-      #if os(iOS)
-        _ = Bundle(path: "\(Injection.resourcePath)/iOSInjection.bundle")?.load()
-      #else
-        _ = Bundle(path: "\(Injection.resourcePath)/tvOSInjection.bundle")?.load()
-      #endif
-    #endif
-
-    closure?()
   /// Transition between windows using `UIView.transition` and make window key and visible.
   /// If there is no previous window, the method will return early and call `.makeKeyAndVisible()`
   /// on the new window.

--- a/Source/iOS+tvOS/UIApplicationDelegate+Extensions.swift
+++ b/Source/iOS+tvOS/UIApplicationDelegate+Extensions.swift
@@ -13,5 +13,28 @@ public extension UIApplicationDelegate {
     #endif
 
     closure?()
+  /// Transition between windows using `UIView.transition` and make window key and visible.
+  /// If there is no previous window, the method will return early and call `.makeKeyAndVisible()`
+  /// on the new window.
+  ///
+  /// - Parameters:
+  ///   - oldWindow: Optional previous window.
+  ///   - window: The new window that should become both key and visible.
+  ///   - handler: A completion closure that takes the new window as its argument.
+  public func transition(from oldWindow: UIWindow?, to window: UIWindow, then handler: @escaping (UIWindow) -> Void) {
+    guard let oldWindow = oldWindow else {
+      window.makeKeyAndVisible()
+      handler(window)
+      return
+    }
+    window.alpha = 0.0
+    window.makeKeyAndVisible()
+    UIView.transition(with: oldWindow, duration: 0.3,
+                      options: .transitionCrossDissolve, animations: {
+                        window.alpha = 1.0
+    }, completion: { _ in
+      oldWindow.alpha = 0.0
+      handler(window)
+    })
   }
 }

--- a/Tests/iOS+tvOS/UIApplicationDelegateTests.swift
+++ b/Tests/iOS+tvOS/UIApplicationDelegateTests.swift
@@ -18,7 +18,7 @@ class UIApplicationDelegateTests: XCTestCase {
 
   func testSettingUpInjection() {
     let applicationDelegate = ApplicationDelegateMock()
-    applicationDelegate.loadInjection(applicationDelegate.loadInitialState)
+    Injection.load(then: applicationDelegate.loadInitialState)
     applicationDelegate.addInjection(with: #selector(ApplicationDelegateMock.injected(_:)))
     utilities.triggerInjection()
     XCTAssertEqual(applicationDelegate.timesInvoked, 1)

--- a/Vaccine.podspec
+++ b/Vaccine.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Vaccine"
   s.summary          = "Make your apps immune to recompile-disease."
-  s.version          = "0.8.0"
+  s.version          = "0.9.0"
   s.homepage         = "https://github.com/zenangst/Vaccine"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }


### PR DESCRIPTION
- Adds window transition extension on `UIApplicationDelegate`
- Removes `loadInjection` from `UIApplicationDelegate`, loading the injection bundle should be done by the `Injection` class