### PR TITLE
Improve swizzling token

### DIFF
--- a/Source/Shared/CollectionView+Extensions.swift
+++ b/Source/Shared/CollectionView+Extensions.swift
@@ -7,7 +7,7 @@ import UIKit
 public extension CollectionView {
   static func _swizzleCollectionViews() {
     #if DEBUG
-    DispatchQueue.once(token: "com.zenangst.Vaccine.swizzleCollectionViews") {
+    DispatchQueue.once(token: "com.zenangst.Vaccine.\(#function)") {
       let originalSelector = #selector(setter: CollectionView.dataSource)
       let swizzledSelector = #selector(CollectionView.vaccine_setDataSource(_:))
       Swizzling.swizzle(UICollectionView.self,

--- a/Source/Shared/TableView+Extensions.swift
+++ b/Source/Shared/TableView+Extensions.swift
@@ -7,7 +7,7 @@ import UIKit
 public extension TableView {
   static func _swizzleTableViews() {
     #if DEBUG
-    DispatchQueue.once(token: "com.zenangst.Vaccine.swizzleTableViews") {
+    DispatchQueue.once(token: "com.zenangst.Vaccine.\(#function)") {
       let originalSelector = #selector(setter: TableView.dataSource)
       let swizzledSelector = #selector(TableView.vaccine_setDataSource(_:))
       Swizzling.swizzle(TableView.self,

--- a/Source/Shared/View+Extensions.swift
+++ b/Source/Shared/View+Extensions.swift
@@ -10,7 +10,7 @@ extension View {
   /// Swizzle initializers for views if application is compiled in debug mode.
   static func _swizzleViews() {
     #if DEBUG
-    DispatchQueue.once(token: "com.zenangst.Vaccine.swizzleViews") {
+    DispatchQueue.once(token: "com.zenangst.Vaccine.\(#function)") {
       let originalSelector = #selector(View.init(frame:))
       let swizzledSelector = #selector(View.init(vaccineFrame:))
       Swizzling.swizzle(View.self,

--- a/Source/Shared/ViewController+Extensions.swift
+++ b/Source/Shared/ViewController+Extensions.swift
@@ -7,7 +7,7 @@
 extension ViewController {
   public static func _swizzleViewControllers() {
     #if DEBUG
-      DispatchQueue.once(token: "com.zenangst.Vaccine.swizzleViewControllers") {
+      DispatchQueue.once(token: "com.zenangst.Vaccine.\(#function)") {
         let originalSelector = #selector(loadView)
         let swizzledSelector = #selector(vaccine_loadView)
         Swizzling.swizzle(ViewController.self,


### PR DESCRIPTION
This PR improves how dispatch tokens are created by using #function instead of regular strings.