### PR TITLE
Implement swizzled injection for collection view layouts

### DIFF
--- a/Source/Shared/CollectionViewLayout+Extensions.swift
+++ b/Source/Shared/CollectionViewLayout+Extensions.swift
@@ -1,0 +1,43 @@
+#if os(macOS)
+import Cocoa
+#else
+import UIKit
+#endif
+
+public extension CollectionViewLayout {
+  static func _swizzleCollectionLayout() {
+    #if DEBUG
+    DispatchQueue.once(token: "com.zenangst.Vaccine.\(#function)") {
+      let originalSelector = _Selector("init")
+      let swizzledSelector = #selector(CollectionViewLayout.init(vaccine_swizzled:))
+      Swizzling.swizzle(CollectionViewLayout.self,
+                        originalSelector: originalSelector,
+                        swizzledSelector: swizzledSelector)
+    }
+    #endif
+  }
+
+  @objc public convenience init(vaccine_swizzled: Bool) {
+    self.init(vaccine_swizzled: true)
+    Injection.add(observer: self, with: #selector(vaccine_layout_injected(_:)))
+  }
+
+  private static func _Selector(_ string: String) -> Selector {
+    return Selector(string)
+  }
+
+  @objc func vaccine_layout_injected(_ notification: Notification) {
+    guard Injection.objectWasInjected(self, in: notification) else { return }
+    #if !os(macOS)
+    if Injection.animations {
+      UIView.animate(withDuration: 0.3) {
+        self.invalidateLayout()
+      }
+    } else {
+      invalidateLayout()
+    }
+    #else
+    invalidateLayout()
+    #endif
+  }
+}

--- a/Source/Shared/Injection.swift
+++ b/Source/Shared/Injection.swift
@@ -65,6 +65,10 @@ public class Injection {
     didSet { if swizzleTableViews { CollectionView._swizzleCollectionViews() } }
   }
 
+  static var swizzleCollectionViewLayouts: Bool = false {
+    didSet { if swizzleTableViews { CollectionViewLayout._swizzleCollectionLayout() } }
+  }
+
   static var swizzleTableViews: Bool = false {
     didSet { if swizzleTableViews { TableView._swizzleTableViews() } }
   }
@@ -124,6 +128,7 @@ public class Injection {
     swizzleViews = swizzling
     swizzleTableViews = swizzling
     swizzleCollectionViews = swizzling
+    swizzleCollectionViewLayouts = swizzling
     self.animations = animations
     handler?()
     return self

--- a/Source/Shared/TypeAlias.swift
+++ b/Source/Shared/TypeAlias.swift
@@ -2,6 +2,7 @@
 import Cocoa
 public typealias CollectionView = NSCollectionView
 public typealias CollectionViewDataSource = NSCollectionViewDataSource
+public typealias CollectionViewLayout = NSCollectionViewLayout
 public typealias TableView = NSTableView
 public typealias TableViewDataSource = NSTableViewDataSource
 
@@ -30,6 +31,7 @@ public typealias ViewController = NSViewController
 import UIKit
 public typealias CollectionView = UICollectionView
 public typealias CollectionViewDataSource = UICollectionViewDataSource
+public typealias CollectionViewLayout = UICollectionViewLayout
 public typealias TableView = UITableView
 public typealias TableViewDataSource = UITableViewDataSource
 /// A view extension that is used to add swizzling of the `init(_ frame: CGRect)` in order

--- a/Vaccine.podspec
+++ b/Vaccine.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Vaccine"
   s.summary          = "Make your apps immune to recompile-disease."
-  s.version          = "0.9.0"
+  s.version          = "0.10.0"
   s.homepage         = "https://github.com/zenangst/Vaccine"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Vaccine.xcodeproj/project.pbxproj
+++ b/Vaccine.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		BD0701C3214B10150065C97F /* CollectionViewLayout+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0701C2214B10150065C97F /* CollectionViewLayout+Extensions.swift */; };
+		BD0701C4214B10150065C97F /* CollectionViewLayout+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0701C2214B10150065C97F /* CollectionViewLayout+Extensions.swift */; };
+		BD0701C5214B10150065C97F /* CollectionViewLayout+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0701C2214B10150065C97F /* CollectionViewLayout+Extensions.swift */; };
 		BD2C456E21385A2D00C17BD6 /* CollectionView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2C456D21385A2D00C17BD6 /* CollectionView+Extensions.swift */; };
 		BD2C456F21385A2D00C17BD6 /* CollectionView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2C456D21385A2D00C17BD6 /* CollectionView+Extensions.swift */; };
 		BD2C457121385AD900C17BD6 /* TableView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2C457021385AD900C17BD6 /* TableView+Extensions.swift */; };
@@ -89,6 +92,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		BD0701C2214B10150065C97F /* CollectionViewLayout+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CollectionViewLayout+Extensions.swift"; sourceTree = "<group>"; };
 		BD2C456D21385A2D00C17BD6 /* CollectionView+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CollectionView+Extensions.swift"; sourceTree = "<group>"; };
 		BD2C457021385AD900C17BD6 /* TableView+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TableView+Extensions.swift"; sourceTree = "<group>"; };
 		BD2F6E6320C93B3200621BC8 /* UIScreenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIScreenTests.swift; sourceTree = "<group>"; };
@@ -315,6 +319,7 @@
 				BD4B8C4920C860CB00836815 /* TypeAlias.swift */,
 				BDFC75872135307B001610EC /* View+Extensions.swift */,
 				BD7242CE20CFC0CB0006DCF7 /* ViewController+Extensions.swift */,
+				BD0701C2214B10150065C97F /* CollectionViewLayout+Extensions.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -577,6 +582,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BD0701C5214B10150065C97F /* CollectionViewLayout+Extensions.swift in Sources */,
 				BD6F516D20B7D6BA001E113B /* Injection.swift in Sources */,
 				BDFC758A2135307B001610EC /* View+Extensions.swift in Sources */,
 				BD2C456F21385A2D00C17BD6 /* CollectionView+Extensions.swift in Sources */,
@@ -609,6 +615,7 @@
 			files = (
 				BD6F516B20B7D6BA001E113B /* Injection.swift in Sources */,
 				BDEA432620C9216C00CF30A2 /* UIScreen+Extensions.swift in Sources */,
+				BD0701C3214B10150065C97F /* CollectionViewLayout+Extensions.swift in Sources */,
 				BDFC75882135307B001610EC /* View+Extensions.swift in Sources */,
 				BD6AC87220B6D5C800CBE8BA /* UIApplicationDelegate+Extensions.swift in Sources */,
 				BD7242C720CFBE760006DCF7 /* Swizzling.swift in Sources */,
@@ -641,6 +648,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BD0701C4214B10150065C97F /* CollectionViewLayout+Extensions.swift in Sources */,
 				BD6F516C20B7D6BA001E113B /* Injection.swift in Sources */,
 				BDFC75892135307B001610EC /* View+Extensions.swift in Sources */,
 				BD2C457321385BAD00C17BD6 /* CollectionView+Extensions.swift in Sources */,


### PR DESCRIPTION
This PR implements swizzled injection for collection view layouts. If you have swizzling enabled and you inject a new layout, the layout will invalidate which causes `prepare()` to run and your new layout will be rendered on screen.