### PR TITLE
Improve auto layout deactivation on views

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,8 +181,9 @@ you simply set these constraints to be deactivated. That way you can add additio
 and the latest pair are the only ones that will be active and in use.
 
 When using `swizzling`, the framework will try and resolve the `layoutConstraints` from your view and deactivate them in order to avoid
-conflict with any new constraints that you may apply in your `loadView()` method. Which means that you can remove the call to `NSLayoutConstraint`
-to deactivate the current constraints.
+conflict with any new constraints that you may apply in your `loadView()` method. Which means that you can remove the call to `NSLayoutConstraint` to deactivate the current constraints. 
+
+**Note**: Using `layoutConstraints` is optional, if your view does not use stored constraints, then Vaccine will recursively deactivate all constraints on all of its subviews when the view gets injected.
 
 ```swift
 class CustomView: UIView {

--- a/Source/Shared/View+Extensions.swift
+++ b/Source/Shared/View+Extensions.swift
@@ -56,7 +56,7 @@ extension View {
 
     if responds(to: selector), Injection.objectWasInjected(self, in: notification) {
       #if os(macOS)
-        closure?()
+        closure()
       #else
         guard Injection.animations else { closure(); return }
 

--- a/Vaccine.podspec
+++ b/Vaccine.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Vaccine"
   s.summary          = "Make your apps immune to recompile-disease."
-  s.version          = "0.10.1"
+  s.version          = "0.10.2"
   s.homepage         = "https://github.com/zenangst/Vaccine"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }


### PR DESCRIPTION
If an injected view does not implement `.layoutConstraints` then `invalidateIfNeededLayoutConstraints` will deactivate constraints on all of it's subviews.