### PR TITLE
Add support for loading Xcode 10 compatible bundle in InjectionIII

### DIFF
--- a/Source/Shared/Injection.swift
+++ b/Source/Shared/Injection.swift
@@ -37,13 +37,13 @@ import Foundation
 ///
 public class Injection {
   /// The file bundle
-  static var bundle: String {
+  static func bundle(version: String = "") -> String {
     #if os(iOS)
-      return "iOSInjection.bundle"
+      return "iOSInjection\(version).bundle"
     #elseif os(tvOS)
-      return "tvOSInjection.bundle"
+      return "tvOSInjection\(version).bundle"
     #else
-      return "macOSInjection.bundle"
+      return "macOSInjection\(version).bundle"
     #endif
   }
 
@@ -53,8 +53,8 @@ public class Injection {
   }
 
   // The path to the injection bundle.
-  static var bundlePath: String {
-    return "\(Injection.resourcePath)/\(Injection.bundle)"
+  static func bundlePath(version: String = "") -> String {
+    return "\(Injection.resourcePath)/\(Injection.bundle(version: version))"
   }
 
   static var swizzleViews: Bool = false {
@@ -118,10 +118,10 @@ public class Injection {
                                              animations: Bool = true) -> Injection.Type {
     guard !Injection.isLoaded else { return self }
 
-    #if targetEnvironment(simulator)
-      _ = Bundle(path: Injection.bundlePath)?.load()
-    #elseif os(macOS)
-      _ = Bundle(path: Injection.bundlePath)?.load()
+    #if targetEnvironment(simulator) || os(macOS)
+      if Bundle(path: Injection.bundlePath(version: "10"))?.load() != false {
+        Bundle(path: Injection.bundlePath())?.load()
+      }
     #endif
 
     swizzleViewControllers = swizzling

--- a/Source/macOS/NSApplicationDelegate+Extensions.swift
+++ b/Source/macOS/NSApplicationDelegate+Extensions.swift
@@ -1,9 +1,0 @@
-import Cocoa
-
-public extension NSApplicationDelegate {
-  func loadInjection(_ closure: (() -> Void)? = nil) {
-    guard !Injection.isLoaded else { return }
-    _ = Bundle(path: Injection.bundlePath)?.load()
-    closure?()
-  }
-}

--- a/Tests/macOS/NSApplicationDelegateTests.swift
+++ b/Tests/macOS/NSApplicationDelegateTests.swift
@@ -18,7 +18,7 @@ class NSApplicationDelegateTests: XCTestCase {
 
   func testSettingUpInjection() {
     let applicationDelegate = ApplicationDelegateMock()
-    applicationDelegate.loadInjection(applicationDelegate.loadInitialState)
+    Injection.load(then: { applicationDelegate.loadInitialState() })
     applicationDelegate.addInjection(with: #selector(ApplicationDelegateMock.injected(_:)))
     utilities.triggerInjection()
     XCTAssertEqual(applicationDelegate.timesInvoked, 1)

--- a/Vaccine.podspec
+++ b/Vaccine.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Vaccine"
   s.summary          = "Make your apps immune to recompile-disease."
-  s.version          = "0.11.0"
+  s.version          = "0.12.0"
   s.homepage         = "https://github.com/zenangst/Vaccine"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Vaccine.xcodeproj/project.pbxproj
+++ b/Vaccine.xcodeproj/project.pbxproj
@@ -28,7 +28,6 @@
 		BD5FC7F420B80D8500A08D21 /* UIViewController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD5FC7F220B80D8500A08D21 /* UIViewController+Extensions.swift */; };
 		BD6AC87220B6D5C800CBE8BA /* UIApplicationDelegate+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD6AC87120B6D5C800CBE8BA /* UIApplicationDelegate+Extensions.swift */; };
 		BD6AC87320B6D5C800CBE8BA /* UIApplicationDelegate+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD6AC87120B6D5C800CBE8BA /* UIApplicationDelegate+Extensions.swift */; };
-		BD6AC87520B6D5ED00CBE8BA /* NSApplicationDelegate+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD6AC87420B6D5ED00CBE8BA /* NSApplicationDelegate+Extensions.swift */; };
 		BD6AC87720B6D61B00CBE8BA /* NSObject+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD6AC87620B6D61B00CBE8BA /* NSObject+Extensions.swift */; };
 		BD6AC87820B6D61B00CBE8BA /* NSObject+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD6AC87620B6D61B00CBE8BA /* NSObject+Extensions.swift */; };
 		BD6AC87920B6D61B00CBE8BA /* NSObject+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD6AC87620B6D61B00CBE8BA /* NSObject+Extensions.swift */; };
@@ -101,7 +100,6 @@
 		BD5FC7EE20B8054500A08D21 /* InjectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InjectionTests.swift; sourceTree = "<group>"; };
 		BD5FC7F220B80D8500A08D21 /* UIViewController+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Extensions.swift"; sourceTree = "<group>"; };
 		BD6AC87120B6D5C800CBE8BA /* UIApplicationDelegate+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplicationDelegate+Extensions.swift"; sourceTree = "<group>"; };
-		BD6AC87420B6D5ED00CBE8BA /* NSApplicationDelegate+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSApplicationDelegate+Extensions.swift"; sourceTree = "<group>"; };
 		BD6AC87620B6D61B00CBE8BA /* NSObject+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSObject+Extensions.swift"; sourceTree = "<group>"; };
 		BD6AC87A20B6D65700CBE8BA /* Vaccine.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = Vaccine.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		BD6AC87B20B6D65700CBE8BA /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
@@ -206,7 +204,6 @@
 		D284B0F41F79024300D94AF3 /* macOS */ = {
 			isa = PBXGroup;
 			children = (
-				BD6AC87420B6D5ED00CBE8BA /* NSApplicationDelegate+Extensions.swift */,
 				BD592EB720B837BB006DE955 /* NSViewController+Extensions.swift */,
 			);
 			path = macOS;
@@ -654,7 +651,6 @@
 				BD2C457321385BAD00C17BD6 /* CollectionView+Extensions.swift in Sources */,
 				BD7242C820CFBE760006DCF7 /* Swizzling.swift in Sources */,
 				BD592EB820B837BB006DE955 /* NSViewController+Extensions.swift in Sources */,
-				BD6AC87520B6D5ED00CBE8BA /* NSApplicationDelegate+Extensions.swift in Sources */,
 				BD7242D020CFC0CB0006DCF7 /* ViewController+Extensions.swift in Sources */,
 				BD2C457421385BB600C17BD6 /* TableView+Extensions.swift in Sources */,
 				BD6AC87820B6D61B00CBE8BA /* NSObject+Extensions.swift in Sources */,


### PR DESCRIPTION
This adds support for loading the correct bundle (built for Xcode 10) in the latest version of InjectionIII.