### PR TITLE
Fix crash on macOS

### DIFF
--- a/Source/Shared/CollectionView+Extensions.swift
+++ b/Source/Shared/CollectionView+Extensions.swift
@@ -25,7 +25,7 @@ public extension CollectionView {
   }
 
   @objc func vaccine_datasource_injected(_ notification: Notification) {
-    guard let dataSource = dataSource else { return }
+    guard window != nil, let dataSource = dataSource else { return }
     guard Injection.objectWasInjected(dataSource, in: notification) else { return }
     reloadData()
   }

--- a/Source/Shared/TableView+Extensions.swift
+++ b/Source/Shared/TableView+Extensions.swift
@@ -25,7 +25,7 @@ public extension TableView {
   }
 
   @objc func vaccine_datasource_injected(_ notification: Notification) {
-    guard let dataSource = dataSource else { return }
+    guard window != nil, let dataSource = dataSource else { return }
     guard Injection.objectWasInjected(dataSource, in: notification) else { return }
     reloadData()
   }

--- a/Vaccine.podspec
+++ b/Vaccine.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Vaccine"
   s.summary          = "Make your apps immune to recompile-disease."
-  s.version          = "0.12.1"
+  s.version          = "0.12.2"
   s.homepage         = "https://github.com/zenangst/Vaccine"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }


### PR DESCRIPTION
Adds safeguards to collection and table view injection code. This helps avoid crashes by checking if the window of the collection or table view is not `nil`.