### PR TITLE
Improve/injection with xcode10

### DIFF
--- a/Source/Shared/Injection.swift
+++ b/Source/Shared/Injection.swift
@@ -92,7 +92,7 @@ public class Injection {
       let url = bundle.bundleURL
         .lastPathComponent
         .lowercased()
-      if url.range(of: "injection.bundle") != nil {
+      if url.range(of: "injection") != nil {
         result = true
         break
       }

--- a/Source/Shared/Injection.swift
+++ b/Source/Shared/Injection.swift
@@ -214,6 +214,11 @@ public class Injection {
       shouldRespondToInjection = object.classForCoder == viewController.classForCoder
     }
 
+    /// Do a dirty match on the class name.
+    if !shouldRespondToInjection {
+      shouldRespondToInjection = "\(object.classForCoder)".lowercased().contains("viewcontroller")
+    }
+
     return shouldRespondToInjection
   }
 

--- a/Vaccine.podspec
+++ b/Vaccine.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Vaccine"
   s.summary          = "Make your apps immune to recompile-disease."
-  s.version          = "0.12.2"
+  s.version          = "0.12.3"
   s.homepage         = "https://github.com/zenangst/Vaccine"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }


### PR DESCRIPTION
- Adds dirty view controller matching as a fallback if view controller cannot be determined using type checking
- Remove `.bundle` from pattern check to see if injection is already loaded.