### PR TITLE
Improve injecting NSViewControllers

### DIFF
--- a/Source/macOS/NSViewController+Extensions.swift
+++ b/Source/macOS/NSViewController+Extensions.swift
@@ -4,8 +4,6 @@ import Cocoa
   private func viewDidLoadIfNeeded(_ notification: Notification) {
     guard Injection.isLoaded else { return }
     guard Injection.viewControllerWasInjected(self, in: notification) else { return }
-
-    NotificationCenter.default.removeObserver(self)
     removeChildViewControllers()
     removeViewsAndLayers()
     viewDidLoad()

--- a/Vaccine.podspec
+++ b/Vaccine.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Vaccine"
   s.summary          = "Make your apps immune to recompile-disease."
-  s.version          = "0.12.3"
+  s.version          = "0.12.4"
   s.homepage         = "https://github.com/zenangst/Vaccine"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }


### PR DESCRIPTION
This refactors how NSViewController's are swizzled on macOS. Instead of using `loadView`, we now use `nibName:bundle:` to add the injection observation.