### PR TITLE
Implement support for animated injections on macOS

### DIFF
--- a/Source/iOS+tvOS/UIViewController+Extensions.swift
+++ b/Source/iOS+tvOS/UIViewController+Extensions.swift
@@ -1,21 +1,71 @@
 import UIKit
 
 @objc public extension UIViewController {
-  /// Removes all child view controllers.
-  private func removeChildViewControllers() {
-    #if swift(>=4.2)
-    children.forEach { controller in
-      controller.willMove(toParent: nil)
-      controller.view.removeFromSuperview()
-      controller.removeFromParent()
+  /// Validate if the current class was injected by checking the contents
+  /// of the notification.
+  ///
+  /// - Parameter notification: A standard InjectionIII notification
+  private func viewDidLoadIfNeeded(_ notification: Notification) {
+    guard Injection.isLoaded else { return }
+    guard Injection.viewControllerWasInjected(self, in: notification) else { return }
+    if !Injection.swizzleViewControllers {
+      NotificationCenter.default.removeObserver(self)
     }
-    #else
-    childViewControllers.forEach { controller in
-      controller.willMove(toParentViewController: nil)
-      controller.view.removeFromSuperview()
-      controller.removeFromParentViewController()
+
+    performInjection()
+  }
+
+  /// Invoke all injection related methods in sequence.
+  /// If this method is invoked with animations enabled,
+  /// a snapshot of the current view will be created and
+  /// added to the applications window in order to nicely
+  /// transition to the new controller view state.
+  private func performInjection() {
+    let options: UIView.AnimationOptions = [.allowAnimatedContent,
+                                            .beginFromCurrentState,
+                                            .layoutSubviews]
+    if Injection.animations, let snapshot = self.view.snapshotView(afterScreenUpdates: false) {
+      let maskView = UIView()
+      maskView.frame.size = snapshot.frame.size
+      maskView.frame.origin.y = navigationController?.navigationBar.frame.maxY ?? 0
+      maskView.backgroundColor = .white
+      snapshot.mask = maskView
+      view.window?.addSubview(snapshot)
+      let oldScrollViews = indexScrollViews()
+      resetViewControllerState()
+      rebuildViewContorllerState()
+      syncOldScrollViews(oldScrollViews, with: indexScrollViews())
+      UIView.animate(withDuration: 0.25, delay: 0.0, options: options, animations: {
+        snapshot.alpha = 0.0
+      }) { _ in
+        snapshot.removeFromSuperview()
+      }
+    } else {
+      let scrollViews = indexScrollViews()
+      lockScreenUpdates(!scrollViews.isEmpty)
+      resetViewControllerState()
+      rebuildViewContorllerState()
+      unlockScreenUpdates(!scrollViews.isEmpty, scrollViews: scrollViews)
     }
-    #endif
+  }
+
+  /// Will invoke `viewDidLoad` to run view controllers setup operations.
+  /// In addition, it will force all subview to layout and collection & table views
+  /// to reload. This is to make sure that we are displaying the latest changes.
+  private func rebuildViewContorllerState() {
+    viewDidLoad()
+    view.subviews.forEach { view in
+      view.setNeedsLayout()
+      view.layoutIfNeeded()
+      view.setNeedsDisplay()
+
+      (view as? UICollectionView)?.reloadData()
+      (view as? UITableView)?.reloadData()
+    }
+
+    view.subviews.filter({ $0.frame.size == .zero }).forEach {
+      $0.sizeToFit()
+    }
   }
 
   /// Lock screen updates using a `CATransaction`.
@@ -46,102 +96,6 @@ import UIKit
     }
   }
 
-  /// Validate if the current class was injected by checking the contents
-  /// of the notification.
-  ///
-  /// - Parameter notification: A standard InjectionIII notification
-  private func viewDidLoadIfNeeded(_ notification: Notification) {
-    guard Injection.isLoaded else { return }
-    guard Injection.viewControllerWasInjected(self, in: notification) else { return }
-    if !Injection.swizzleViewControllers {
-      NotificationCenter.default.removeObserver(self)
-    }
-
-    performInjection()
-  }
-
-  /// Clean up view hierarchy by removing child view controllers, view and layers.
-  private func performCleanUp() {
-    switch self {
-    case _ as UINavigationController:
-      break
-    case let tabBarController as UITabBarController:
-      tabBarController.setViewControllers([], animated: true)
-    default:
-      removeChildViewControllers()
-      removeViewsAndLayers()
-    }
-  }
-
-  /// Invoke all injection related methods in sequence.
-  /// If this method is invoked with animations enabled,
-  /// a snapshot of the current view will be created and
-  /// added to the applications window in order to nicely
-  /// transition to the new controller view state.
-  private func performInjection() {
-    let options: UIView.AnimationOptions = [.allowAnimatedContent,
-                                           .beginFromCurrentState,
-                                           .layoutSubviews]
-    if Injection.animations, let snapshot = self.view.snapshotView(afterScreenUpdates: false) {
-      let maskView = UIView()
-      maskView.frame.size = snapshot.frame.size
-      maskView.frame.origin.y = navigationController?.navigationBar.frame.maxY ?? 0
-      maskView.backgroundColor = .white
-      snapshot.mask = maskView
-      view.window?.addSubview(snapshot)
-      let oldScrollViews = indexScrollViews()
-      performCleanUp()
-      reloadUserInterface()
-      syncOldScrollViews(oldScrollViews, with: indexScrollViews())
-      UIView.animate(withDuration: 0.25, delay: 0.0, options: options, animations: {
-        snapshot.alpha = 0.0
-      }) { _ in
-        snapshot.removeFromSuperview()
-      }
-    } else {
-      let scrollViews = indexScrollViews()
-      lockScreenUpdates(!scrollViews.isEmpty)
-      performCleanUp()
-      reloadUserInterface()
-      unlockScreenUpdates(!scrollViews.isEmpty, scrollViews: scrollViews)
-    }
-  }
-
-  /// Sync two scroll views content offset if they are of the same type.
-  ///
-  /// - Parameters:
-  ///   - oldScrollViews: An array of scroll views from before the injection occured.
-  ///   - newScrollViews: An array of new scroll views after the injection occured.
-  private func syncOldScrollViews(_ oldScrollViews: [UIScrollView], with newScrollViews: [UIScrollView]) {
-    for (offset, scrollView) in newScrollViews.enumerated() {
-      if offset < oldScrollViews.count {
-        let oldScrollView = oldScrollViews[offset]
-        if type(of: scrollView) == type(of: oldScrollView) {
-          scrollView.contentOffset = oldScrollView.contentOffset
-        }
-      }
-    }
-  }
-
-  /// Will invoke `viewDidLoad` to run view controllers setup operations.
-  /// In addition, it will force all subview to layout and collection & table views
-  /// to reload. This is to make sure that we are displaying the latest changes.
-  private func reloadUserInterface() {
-    viewDidLoad()
-    view.subviews.forEach { view in
-      view.setNeedsLayout()
-      view.layoutIfNeeded()
-      view.setNeedsDisplay()
-
-      (view as? UICollectionView)?.reloadData()
-      (view as? UITableView)?.reloadData()
-    }
-
-    view.subviews.filter({ $0.frame.size == .zero }).forEach {
-      $0.sizeToFit()
-    }
-  }
-
   /// Create an index of the content offsets for all underlying scroll views.
   ///
   /// - Returns: A dictionary of scroll views and their current origin.
@@ -164,6 +118,52 @@ import UIKit
     }
 
     return scrollViews
+  }
+
+  /// Sync two scroll views content offset if they are of the same type.
+  ///
+  /// - Parameters:
+  ///   - oldScrollViews: An array of scroll views from before the injection occured.
+  ///   - newScrollViews: An array of new scroll views after the injection occured.
+  private func syncOldScrollViews(_ oldScrollViews: [UIScrollView], with newScrollViews: [UIScrollView]) {
+    for (offset, scrollView) in newScrollViews.enumerated() {
+      if offset < oldScrollViews.count {
+        let oldScrollView = oldScrollViews[offset]
+        if type(of: scrollView) == type(of: oldScrollView) {
+          scrollView.contentOffset = oldScrollView.contentOffset
+        }
+      }
+    }
+  }
+
+  /// Removes all child view controllers.
+  private func removeChildViewControllers() {
+    #if swift(>=4.2)
+    children.forEach { controller in
+      controller.willMove(toParent: nil)
+      controller.view.removeFromSuperview()
+      controller.removeFromParent()
+    }
+    #else
+    childViewControllers.forEach { controller in
+      controller.willMove(toParentViewController: nil)
+      controller.view.removeFromSuperview()
+      controller.removeFromParentViewController()
+    }
+    #endif
+  }
+
+  /// Clean up view hierarchy by removing child view controllers, view and layers.
+  private func resetViewControllerState() {
+    switch self {
+    case _ as UINavigationController:
+      break
+    case let tabBarController as UITabBarController:
+      tabBarController.setViewControllers([], animated: true)
+    default:
+      removeChildViewControllers()
+      removeViewsAndLayers()
+    }
   }
 
   /// Removes all views and layers from a view.

--- a/Source/macOS/NSViewController+Extensions.swift
+++ b/Source/macOS/NSViewController+Extensions.swift
@@ -1,32 +1,150 @@
 import Cocoa
 
 @objc public extension NSViewController {
+  /// Validate if the current class was injected by checking the contents
+  /// of the notification.
+  ///
+  /// - Parameter notification: A standard InjectionIII notification
   private func viewDidLoadIfNeeded(_ notification: Notification) {
     guard Injection.isLoaded else { return }
     guard Injection.viewControllerWasInjected(self, in: notification) else { return }
-    removeChildViewControllers()
-    removeViewsAndLayers()
+    performInjection()
+  }
+
+  /// Invoke all injection related methods in sequence.
+  /// If this method is invoked with animations enabled,
+  /// a snapshot of the current view will be created and
+  /// added to the applications window in order to nicely
+  /// transition to the new controller view state.
+  private func performInjection() {
+    guard !(self is NSCollectionViewItem) else {
+      reloadCollectionViewItem()
+      return
+    }
+
+    if Injection.animations {
+      let snapshot = createSnapshot()
+      let oldScrollViews = indexScrollViews()
+      resetViewControllerState()
+      rebuildViewContorllerState()
+      self.view.window?.contentView?.addSubview(snapshot)
+      syncOldScrollViews(oldScrollViews, with: indexScrollViews())
+      NSAnimationContext.runAnimationGroup({ (context) in
+        context.allowsImplicitAnimation = true
+        context.duration = 0.25
+        snapshot.animator().alphaValue = 0.0
+      }, completionHandler: {
+        snapshot.removeFromSuperview()
+      })
+    } else {
+      let scrollViews = indexScrollViews()
+      lockScreenUpdates(!scrollViews.isEmpty)
+      resetViewControllerState()
+      rebuildViewContorllerState()
+      unlockScreenUpdates(!scrollViews.isEmpty, scrollViews: scrollViews)
+    }
+  }
+
+  private func reloadCollectionViewItem() {
+    if Injection.animations {
+
+      NSAnimationContext.runAnimationGroup({ (context) in
+        context.allowsImplicitAnimation = true
+        context.duration = 0.25
+        resetViewControllerState()
+        rebuildViewContorllerState()
+      }, completionHandler: {})
+    } else {
+      lockScreenUpdates(true)
+      resetViewControllerState()
+      rebuildViewContorllerState()
+      unlockScreenUpdates(true, scrollViews: [])
+    }
+  }
+
+  /// Will invoke `viewDidLoad` to run view controllers setup operations.
+  /// In addition, it will force all subview to layout and collection & table views
+  /// to reload. This is to make sure that we are displaying the latest changes.
+  private func rebuildViewContorllerState() {
     viewDidLoad()
     view.subviews.forEach { view in
-      view.layout()
-      view.display()
+      view.needsLayout = true
+      view.needsDisplay = true
 
       (view as? NSTableView)?.reloadData()
       (view as? NSCollectionView)?.reloadData()
     }
   }
 
-  private func removeViewsAndLayers() {
-    view.subviews.forEach {
-      $0.removeConstraints($0.constraints)
-      $0.removeFromSuperview()
-    }
+  /// Lock screen updates using a `CATransaction`.
+  ///
+  /// - Parameter shouldLock: A boolean value indicating if the method should
+  ///                         be invoked or not. This is determined by the
+  ///                         amount of child view controllers in the controller.
+  private func lockScreenUpdates(_ shouldLock: Bool) {
+    guard shouldLock else { return }
+    CATransaction.begin()
+    CATransaction.lock()
+  }
 
-    if let sublayers = self.view.layer?.sublayers {
-      sublayers.forEach { $0.removeFromSuperlayer() }
+  /// Unlock screen updates using a `CATransaction`.
+  ///
+  /// - Parameters:
+  /// - Parameter shouldLock: A boolean value indicating if the method should
+  ///                         be invoked or not. This is determined by the
+  ///                         amount of child view controllers in the controller.
+  ///   - scrollViews: A dictionary of scroll views related to the view controller.
+  private func unlockScreenUpdates(_ shouldUnlock: Bool, scrollViews: [NSScrollView]) {
+    guard shouldUnlock else { return }
+    syncOldScrollViews(scrollViews, with: indexScrollViews())
+    let nearFuture = DispatchTime.now() + 0.3
+    DispatchQueue.main.asyncAfter(deadline: nearFuture) {
+      CATransaction.unlock()
+      CATransaction.commit()
     }
   }
 
+  /// Create an index of the content offsets for all underlying scroll views.
+  ///
+  /// - Returns: A dictionary of scroll views and their current origin.
+  private func indexScrollViews() -> [NSScrollView] {
+    var scrollViews = [NSScrollView]()
+    for case let scrollView as NSScrollView in view.subviews {
+      scrollViews.append(scrollView)
+    }
+
+    if let parentViewController = parent {
+      for case let scrollView as NSScrollView in parentViewController.view.subviews {
+        scrollViews.append(scrollView)
+      }
+    }
+
+    for childViewController in children {
+      for case let scrollView as NSScrollView in childViewController.view.subviews {
+        scrollViews.append(scrollView)
+      }
+    }
+
+    return scrollViews
+  }
+
+  /// Sync two scroll views content offset if they are of the same type.
+  ///
+  /// - Parameters:
+  ///   - oldScrollViews: An array of scroll views from before the injection occured.
+  ///   - newScrollViews: An array of new scroll views after the injection occured.
+  private func syncOldScrollViews(_ oldScrollViews: [NSScrollView], with newScrollViews: [NSScrollView]) {
+    for (offset, scrollView) in newScrollViews.enumerated() {
+      if offset < oldScrollViews.count {
+        let oldScrollView = oldScrollViews[offset]
+        if type(of: scrollView) == type(of: oldScrollView) {
+          scrollView.contentView.scroll(to: oldScrollView.documentVisibleRect.origin)
+        }
+      }
+    }
+  }
+
+  /// Removes all child view controllers.
   private func removeChildViewControllers() {
     #if swift(>=4.2)
     children.forEach {
@@ -35,13 +153,54 @@ import Cocoa
     }
     #else
     childViewControllers.forEach {
-      $0.view.removeFromSuperview()
-      $0.removeFromParentViewController()
+    $0.view.removeFromSuperview()
+    $0.removeFromParentViewController()
     }
     #endif
   }
 
+  private func createSnapshot() -> NSImageView {
+    let snapshot = NSImageView()
+    snapshot.image = view.snapshot
+    snapshot.frame.size = self.view.frame.size
+    return snapshot
+  }
+
+  /// Clean up view hierarchy by removing child view controllers, view and layers.
+  private func resetViewControllerState() {
+    removeChildViewControllers()
+    removeViewsAndLayers()
+  }
+
+  /// Removes all views and layers from a view.
+  private func removeViewsAndLayers() {
+    view.subviews.forEach {
+      $0.removeFromSuperview()
+    }
+
+    if let sublayers = self.view.layer?.sublayers {
+      sublayers.forEach { $0.removeFromSuperlayer() }
+    }
+  }
+
   @objc func injected(_ notification: Notification) {
     viewDidLoadIfNeeded(notification)
+  }
+}
+
+fileprivate extension NSView {
+  var snapshot: NSImage {
+    guard let bitmapRep = bitmapImageRepForCachingDisplay(in: bounds) else { return NSImage() }
+    cacheDisplay(in: bounds, to: bitmapRep)
+    let image = NSImage()
+    image.addRepresentation(bitmapRep)
+    bitmapRep.size = bounds.size.doubleScale()
+    return image
+  }
+}
+
+fileprivate extension CGSize {
+  func doubleScale() -> CGSize {
+    return CGSize(width: width * 2, height: height * 2)
   }
 }

--- a/Vaccine.podspec
+++ b/Vaccine.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Vaccine"
   s.summary          = "Make your apps immune to recompile-disease."
-  s.version          = "0.12.4"
+  s.version          = "0.13.0"
   s.homepage         = "https://github.com/zenangst/Vaccine"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }


### PR DESCRIPTION
Implement animations when injecting view controllers and collection view items on macOS. It syncs the source code between macOS, iOS, and tvOS. Also, it improves injecting collection view items on the macOS platform by going a different path when those kinds of view controllers are injected.