### PR TITLE
Improve removing constraints from views

### DIFF
--- a/Vaccine.podspec
+++ b/Vaccine.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Vaccine"
   s.summary          = "Make your apps immune to recompile-disease."
-  s.version          = "0.13.0"
+  s.version          = "0.13.1"
   s.homepage         = "https://github.com/zenangst/Vaccine"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }


### PR DESCRIPTION
Refactors how constraints are removed from when views are injected. It makes a special case to take care of `UITableViewCell`'s because it has a `contentView` that should act as the root view.