### PR TITLE
Use the view setter instead of init(nibName:bundle:)

### DIFF
--- a/Source/Shared/ViewController+Extensions.swift
+++ b/Source/Shared/ViewController+Extensions.swift
@@ -35,25 +35,27 @@ extension ViewController {
       Injection.addViewController(self)
     }
   #else
-    public static func _swizzleViewControllers() {
-      #if DEBUG
-      DispatchQueue.once(token: "com.zenangst.Vaccine.\(#function)") {
-        let originalSelector = #selector(ViewController.init(nibName:bundle:))
-        let swizzledSelector = #selector(ViewController.init(vaccine_swizzled_nibName:bundle:))
-        Swizzling.swizzle(ViewController.self,
-                          originalSelector: originalSelector,
-                          swizzledSelector: swizzledSelector)
-      }
-      #endif
+  public static func _swizzleViewControllers() {
+    #if DEBUG
+    DispatchQueue.once(token: "com.zenangst.Vaccine.\(#function)") {
+      let originalSelector = #selector(setter: ViewController.view)
+      let swizzledSelector = #selector(ViewController.vaccine_setView(_:))
+      Swizzling.swizzle(ViewController.self,
+                        originalSelector: originalSelector,
+                        swizzledSelector: swizzledSelector)
     }
+    #endif
+  }
 
-    private static func _Selector(_ string: String) -> Selector {
-      return Selector(string)
-    }
+  private static func _Selector(_ string: String) -> Selector {
+    return Selector(string)
+  }
 
-  @objc public convenience init(vaccine_swizzled_nibName: NSNib.Name?, bundle: Bundle?) {
-      self.init(vaccine_swizzled_nibName: vaccine_swizzled_nibName, bundle: bundle)
+  @objc func vaccine_setView(_ view: View?) {
+    if isViewLoaded == false && view != nil {
       Injection.addViewController(self)
     }
+    self.vaccine_setView(view)
+  }
   #endif
 }

--- a/Vaccine.podspec
+++ b/Vaccine.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Vaccine"
   s.summary          = "Make your apps immune to recompile-disease."
-  s.version          = "0.13.1"
+  s.version          = "0.13.2"
   s.homepage         = "https://github.com/zenangst/Vaccine"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }


### PR DESCRIPTION
This refactors view controller swizzling on macOS to use a different method in order to avoid modifying private classes and adding notifications before the view has been loaded.