### PR TITLE
Improve using Vaccine with nibs/xibs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-osx_image: xcode10
+osx_image: xcode10.1
 language: objective-c
 
 script:

--- a/Source/Shared/Injection.swift
+++ b/Source/Shared/Injection.swift
@@ -191,6 +191,7 @@ public class Injection {
 
   static func viewControllerWasInjected(_ viewController: ViewController,
                                         in notification: Notification) -> Bool {
+    
     if objectWasInjected(self, in: notification) { return true }
     guard let object = object(from: notification) else {
       return false
@@ -214,10 +215,19 @@ public class Injection {
       shouldRespondToInjection = object.classForCoder == viewController.classForCoder
     }
 
+
+    let objectName = "\(object.classForCoder)".lowercased()
+
     /// Do a dirty match on the class name.
     if !shouldRespondToInjection {
-      shouldRespondToInjection = "\(object.classForCoder)".lowercased().contains("viewcontroller")
+      shouldRespondToInjection = objectName.contains("viewcontroller")
     }
+
+    if !shouldRespondToInjection, objectName.contains("cell") {
+      let allSubviews = viewController.view.subviewsRecursive()
+      shouldRespondToInjection = !allSubviews.filter({ $0 is TableView || $0 is CollectionView }).isEmpty
+    }
+
 
     return shouldRespondToInjection
   }

--- a/Source/Shared/View+Extensions.swift
+++ b/Source/Shared/View+Extensions.swift
@@ -23,7 +23,7 @@ extension View {
   /// Recursively gather all subviews into a single collection.
   ///
   /// - Returns: A collection of views.
-  private func subviewsRecursive() -> [View] {
+  func subviewsRecursive() -> [View] {
     return subviews + subviews.flatMap { $0.subviewsRecursive() }
   }
 

--- a/Source/Shared/ViewController+Extensions.swift
+++ b/Source/Shared/ViewController+Extensions.swift
@@ -17,24 +17,6 @@ extension ViewController {
   #endif
 
 
-  #if !os(macOS)
-    public static func _swizzleViewControllers() {
-      #if DEBUG
-        DispatchQueue.once(token: "com.zenangst.Vaccine.\(#function)") {
-          let originalSelector = #selector(loadView)
-          let swizzledSelector = #selector(vaccine_loadView)
-          Swizzling.swizzle(ViewController.self,
-                            originalSelector: originalSelector,
-                            swizzledSelector: swizzledSelector)
-        }
-      #endif
-    }
-
-    @objc func vaccine_loadView() {
-      vaccine_loadView()
-      Injection.addViewController(self)
-    }
-  #else
   public static func _swizzleViewControllers() {
     #if DEBUG
     DispatchQueue.once(token: "com.zenangst.Vaccine.\(#function)") {
@@ -57,5 +39,4 @@ extension ViewController {
     }
     self.vaccine_setView(view)
   }
-  #endif
 }

--- a/Source/iOS+tvOS/UIViewController+Extensions.swift
+++ b/Source/iOS+tvOS/UIViewController+Extensions.swift
@@ -33,7 +33,7 @@ import UIKit
       view.window?.addSubview(snapshot)
       let oldScrollViews = indexScrollViews()
 
-      if nibName == nil && nibBundle == nil {
+      if nibName == nil {
         resetViewControllerState()
         rebuildViewControllerState()
       } else {
@@ -50,7 +50,7 @@ import UIKit
       let scrollViews = indexScrollViews()
       lockScreenUpdates(!scrollViews.isEmpty)
 
-      if nibName == nil && nibBundle == nil {
+      if nibName == nil {
         resetViewControllerState()
         rebuildViewControllerState()
       } else {

--- a/Source/iOS+tvOS/UIViewController+Extensions.swift
+++ b/Source/iOS+tvOS/UIViewController+Extensions.swift
@@ -32,8 +32,14 @@ import UIKit
       snapshot.mask = maskView
       view.window?.addSubview(snapshot)
       let oldScrollViews = indexScrollViews()
-      resetViewControllerState()
-      rebuildViewContorllerState()
+
+      if nibName == nil && nibBundle == nil {
+        resetViewControllerState()
+        rebuildViewControllerState()
+      } else {
+        rebuildNibViewControllerState()
+      }
+
       syncOldScrollViews(oldScrollViews, with: indexScrollViews())
       UIView.animate(withDuration: 0.25, delay: 0.0, options: options, animations: {
         snapshot.alpha = 0.0
@@ -43,16 +49,37 @@ import UIKit
     } else {
       let scrollViews = indexScrollViews()
       lockScreenUpdates(!scrollViews.isEmpty)
-      resetViewControllerState()
-      rebuildViewContorllerState()
+
+      if nibName == nil && nibBundle == nil {
+        resetViewControllerState()
+        rebuildViewControllerState()
+      } else {
+        rebuildNibViewControllerState()
+      }
+
       unlockScreenUpdates(!scrollViews.isEmpty, scrollViews: scrollViews)
     }
+  }
+
+  private func rebuildNibViewControllerState() {
+    let subviews = view.subviewsRecursive()
+
+    for case let tableView as UITableView in subviews {
+      tableView.reloadData()
+    }
+
+    for case let collectionView as UICollectionView in subviews {
+      collectionView.reloadData()
+    }
+
+    viewWillAppear(false)
+    viewDidAppear(false)
   }
 
   /// Will invoke `viewDidLoad` to run view controllers setup operations.
   /// In addition, it will force all subview to layout and collection & table views
   /// to reload. This is to make sure that we are displaying the latest changes.
-  private func rebuildViewContorllerState() {
+  private func rebuildViewControllerState() {
     viewDidLoad()
     view.subviews.forEach { view in
       view.setNeedsLayout()

--- a/Vaccine.podspec
+++ b/Vaccine.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Vaccine"
   s.summary          = "Make your apps immune to recompile-disease."
-  s.version          = "0.13.4"
+  s.version          = "0.14.0"
   s.homepage         = "https://github.com/zenangst/Vaccine"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }


### PR DESCRIPTION
- Refactors how view controllers are swizzled, it now shares the implemention with macOS
- Use `subviewsRecursive()` to look for table and collection views
- Add matching on cell when evaluating if a view controller should respond to injection
- Add method for handling nib-based view controllers