### PR TITLE
Improve injecting child view controllers on macOS

### DIFF
--- a/Source/macOS/NSViewController+Extensions.swift
+++ b/Source/macOS/NSViewController+Extensions.swift
@@ -74,6 +74,8 @@ import Cocoa
       (view as? NSTableView)?.reloadData()
       (view as? NSCollectionView)?.reloadData()
     }
+    viewWillAppear()
+    viewDidAppear()
   }
 
   /// Lock screen updates using a `CATransaction`.

--- a/Source/macOS/NSViewController+Extensions.swift
+++ b/Source/macOS/NSViewController+Extensions.swift
@@ -8,7 +8,16 @@ import Cocoa
   private func viewDidLoadIfNeeded(_ notification: Notification) {
     guard Injection.isLoaded else { return }
     guard Injection.viewControllerWasInjected(self, in: notification) else { return }
-    performInjection()
+
+    if !children.isEmpty && parent == nil {
+      let snapshot = createSnapshot()
+      self.view.window?.contentView?.addSubview(snapshot)
+      DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+        self?.performInjection(snapshot)
+      }
+    } else {
+      performInjection()
+    }
   }
 
   /// Invoke all injection related methods in sequence.
@@ -16,25 +25,25 @@ import Cocoa
   /// a snapshot of the current view will be created and
   /// added to the applications window in order to nicely
   /// transition to the new controller view state.
-  private func performInjection() {
+  private func performInjection(_ snapshot: NSImageView? = nil) {
     guard !(self is NSCollectionViewItem) else {
       reloadCollectionViewItem()
       return
     }
 
     if Injection.animations {
-      let snapshot = createSnapshot()
+      let currentSnapshot = snapshot ?? createSnapshot()
       let oldScrollViews = indexScrollViews()
       resetViewControllerState()
       rebuildViewContorllerState()
-      self.view.window?.contentView?.addSubview(snapshot)
+      self.view.window?.contentView?.addSubview(currentSnapshot)
       syncOldScrollViews(oldScrollViews, with: indexScrollViews())
       NSAnimationContext.runAnimationGroup({ (context) in
         context.allowsImplicitAnimation = true
         context.duration = 0.25
-        snapshot.animator().alphaValue = 0.0
+        currentSnapshot.animator().alphaValue = 0.0
       }, completionHandler: {
-        snapshot.removeFromSuperview()
+        currentSnapshot.removeFromSuperview()
       })
     } else {
       let scrollViews = indexScrollViews()
@@ -155,8 +164,8 @@ import Cocoa
     }
     #else
     childViewControllers.forEach {
-    $0.view.removeFromSuperview()
-    $0.removeFromParentViewController()
+      $0.view.removeFromSuperview()
+      $0.removeFromParentViewController()
     }
     #endif
   }

--- a/Tests/macOS/ViewControllerTests.swift
+++ b/Tests/macOS/ViewControllerTests.swift
@@ -37,9 +37,17 @@ class ViewControllerTests: XCTestCase {
     let _ = viewController.view
     XCTAssertEqual(viewController.timesInvoked, 1)
     utilities.triggerInjection(viewController)
-    XCTAssertEqual(viewController.timesInvoked, 2)
-    XCTAssertEqual(viewController.children.count, 1)
-    XCTAssertEqual(viewController.view.subviews.count, 1)
-    XCTAssertEqual(viewController.view.layer?.sublayers?.count, 1)
+
+    let expectation = XCTestExpectation(description: "Wait for injection to trigger")
+
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+      XCTAssertEqual(viewController.timesInvoked, 2)
+      XCTAssertEqual(viewController.children.count, 1)
+      XCTAssertEqual(viewController.view.subviews.count, 1)
+      XCTAssertEqual(viewController.view.layer?.sublayers?.count, 1)
+      expectation.fulfill()
+    }
+
+    wait(for: [expectation], timeout: 5.0)
   }
 }

--- a/Vaccine.podspec
+++ b/Vaccine.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Vaccine"
   s.summary          = "Make your apps immune to recompile-disease."
-  s.version          = "0.14.1"
+  s.version          = "0.15.0"
   s.homepage         = "https://github.com/zenangst/Vaccine"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }


### PR DESCRIPTION
This improves injecting view controllers that have child view controllers on macOS.
It does this by delaying the perform injection so that the parent view controllers methods are added last, so it reverses the hierarchy.