### PR TITLE
fix: Skip main bundle path checking to know if injection is loaded

### DIFF
--- a/Source/Shared/Injection.swift
+++ b/Source/Shared/Injection.swift
@@ -86,10 +86,6 @@ public class Injection {
       return true
     }
 
-    if !Bundle.main.bundlePath.lowercased().contains("products/debug") {
-      return true
-    }
-
     // Search for injection in the loaded bundles.
     var result: Bool = false
     for bundle in Bundle.allBundles {


### PR DESCRIPTION
Remove mac bundle check to make it work on iOS.